### PR TITLE
Migrate from using external modeladmin to using Wagtail Viewsets

### DIFF
--- a/adl/src/adl/core/models.py
+++ b/adl/src/adl/core/models.py
@@ -340,9 +340,7 @@ class NetworkConnection(PolymorphicModel, ClusterableModel):
                               help_text=_("Plugin to use for this network"))
     plugin_processing_enabled = models.BooleanField(default=True, verbose_name=_("Active"),
                                                     help_text=_("If unchecked, the plugin will NOT run automatically"))
-    plugin_processing_interval = models.PositiveIntegerField(default=15,
-                                                             verbose_name=_("Plugin Auto Processing Interval "
-                                                                            "in Minutes"),
+    plugin_processing_interval = models.PositiveIntegerField(default=15, verbose_name=_("Interval"),
                                                              help_text=_("How often the plugin should run, in minutes"),
                                                              validators=[
                                                                  MaxValueValidator(30),

--- a/adl/src/adl/core/models.py
+++ b/adl/src/adl/core/models.py
@@ -22,6 +22,7 @@ from wagtail.models import Orderable
 from wagtail.snippets.models import register_snippet
 from wagtailgeowidget.panels import LeafletPanel
 
+from adl.core.registries import plugin_registry
 from .dispatchers import get_dispatch_channel_data
 from .dispatchers.wis2box import upload_to_wis2box
 from .tasks import create_or_update_aggregation_periodic_tasks
@@ -192,6 +193,12 @@ class Unit(models.Model):
     description = models.TextField(verbose_name=_("Description"), blank=True, null=True,
                                    help_text=_("Description of the unit"))
     
+    panels = [
+        FieldPanel("name"),
+        FieldPanel("symbol"),
+        FieldPanel("description"),
+    ]
+    
     class Meta:
         verbose_name = _("Unit")
         verbose_name_plural = _("Units")
@@ -361,6 +368,17 @@ class NetworkConnection(PolymorphicModel, ClusterableModel):
     
     def __str__(self):
         return self.name
+    
+    def get_plugin(self):
+        plugin_type = self.plugin
+        plugin = plugin_registry.get(plugin_type)
+        return plugin
+    
+    def run_plugin_process(self):
+        plugin = self.get_plugin()
+        if not plugin:
+            raise ValueError(f"Plugin {self.plugin} not found in the registry.")
+        return plugin.run_process(self)
 
 
 class StationLink(PolymorphicModel, ClusterableModel):

--- a/adl/src/adl/core/registries.py
+++ b/adl/src/adl/core/registries.py
@@ -101,3 +101,14 @@ class CustomUnitContextRegistry(Registry):
 
 
 custom_unit_context_registry = CustomUnitContextRegistry()
+
+
+class ViewSetRegistry(Registry):
+    def __init__(self, name, allow_instance_override=True):
+        self.name = name
+        super().__init__(allow_instance_override=allow_instance_override)
+
+
+dispatch_channel_viewset_registry = ViewSetRegistry(name="dispatch_channel_viewset_registry")
+connection_viewset_registry = ViewSetRegistry(name="connection_viewset_registry")
+station_link_viewset_registry = ViewSetRegistry(name="station_link_viewset_registry")

--- a/adl/src/adl/core/templates/core/card_view.html
+++ b/adl/src/adl/core/templates/core/card_view.html
@@ -1,0 +1,78 @@
+{% load wagtailadmin_tags adl_tags %}
+
+
+<style>
+    .card-view {
+        display: flex;
+        gap: 40px;
+        margin: 40px 0;
+    }
+
+    .listing-card {
+        display: flex;
+        flex-direction: column;
+        padding: 16px;
+        border-radius: 8px;
+        box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1), 0 1px 3px rgba(0, 0, 0, 0.06);
+        min-height: 200px;
+        min-width: 400px;
+    }
+
+    .card-header {
+        display: flex;
+        align-items: center;
+        width: 100%;
+        border-bottom: 1px solid #e4e4e4;
+    }
+
+    .card-icon svg {
+        height: 20px;
+        width: 20px;
+        fill: currentColor;
+    }
+
+
+    .card-title {
+        display: flex;
+        flex: 1;
+        align-items: center;
+        justify-content: space-between;
+        font-size: 16px;
+        font-weight: 500;
+        margin-left: 4px;
+    }
+</style>
+
+<div class="card-view nice-padding">
+    {% for row in table.rows %}
+        <div class="listing-card">
+            {% for column in table.columns.values %}
+                {% if forloop.first %}
+                    <div class="listing card-header">
+                        <div class="card-icon">
+                            {% icon name="plug" %}
+                        </div>
+                        <div class="card-title">
+                            {% component row|get_item:column.name %}
+                        </div>
+                    </div>
+
+                {% else %}
+                    <div style="display:flex;align-items: center;margin-bottom:20px;">
+                        <strong>
+                            {{ column.label }}:
+                        </strong>
+                        <div style="margin-left:10px">
+                            {% component row|get_item:column.name %}
+                        </div>
+                    </div>
+                {% endif %}
+            {% endfor %}
+        </div>
+    {% endfor %}
+</div>
+
+
+
+
+

--- a/adl/src/adl/core/templates/core/connection_list.html
+++ b/adl/src/adl/core/templates/core/connection_list.html
@@ -1,3 +1,96 @@
-{% extends "wagtailadmin/generic/index.html" %}
+{% extends "wagtailadmin/generic/base.html" %}
 
-{% load i18n wagtailadmin_tags static %}
+{% load i18n wagtailadmin_tags static wagtailiconchooser_tags %}
+
+
+{% block main_content %}
+    <style>
+        .c-panels-container {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 30px;
+            padding: 16px;
+            margin-top: 40px;
+        }
+
+        .c-panel {
+            display: flex;
+            flex-direction: column;
+            padding: 16px;
+            border-radius: 8px;
+            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1), 0 1px 3px rgba(0, 0, 0, 0.06);
+            min-height: 200px;
+            min-width: 400px;
+        }
+
+        .c-panel-header {
+            display: flex;
+            align-items: center;
+            border-bottom: 1px solid #e4e4e4;
+        }
+
+        .c-panel-icon svg {
+            height: 28px;
+            width: 28px;
+        }
+
+        .c-panel-title {
+            font-size: 1.2em;
+            font-weight: bold;
+            margin-left: 10px;
+        }
+
+        .c-panel-body {
+            display: flex;
+            flex: 1;
+            padding: 16px 0;
+            flex-direction: column;
+            justify-content: center;
+        }
+
+        .c-panel-meta {
+            margin-bottom: 10px;
+        }
+
+        .c-panel-meta-item {
+            display: flex;
+            align-items: center;
+            gap: 5px;
+        }
+
+    </style>
+
+    <div class="c-panels-container">
+        {% for item in plugin_connections %}
+            <div class="c-panel">
+                <div class="c-panel-header">
+                    <div class="c-panel-icon">
+                        {% icon name="plug" classname="..." title="..." %}
+                    </div>
+                    <div class="c-panel-title">
+                        {{ item.plugin.name }}
+                    </div>
+                </div>
+                <div class="c-panel-body">
+                    <div class="c-panel-meta">
+                        <div class="c-panel-meta-item">
+                            <strong>Connections:</strong> {{ item.connection.count }}
+                        </div>
+                    </div>
+                    <div class="c-panel-link">
+                        <a href="{{ item.connection.index_url }}" class="button bicolor button--icon button-secondary">
+                            <span class="icon-wrapper">
+                                <svg class="icon icon-list-ul icon" aria-hidden="true">
+                                    <use href="#icon-list-ul"></use>
+                                </svg>
+                            </span>
+                            View Connections
+                        </a>
+                    </div>
+                </div>
+            </div>
+        {% endfor %}
+    </div>
+
+{% endblock %}
+

--- a/adl/src/adl/core/templates/core/connection_list.html
+++ b/adl/src/adl/core/templates/core/connection_list.html
@@ -30,8 +30,8 @@
         }
 
         .c-panel-icon svg {
-            height: 28px;
-            width: 28px;
+            height: 20px;
+            width: 20px;
         }
 
         .c-panel-title {
@@ -58,6 +58,10 @@
             gap: 5px;
         }
 
+        .c-panel-link {
+            margin-top: 10px;
+        }
+
     </style>
 
     <div class="c-panels-container">
@@ -65,7 +69,7 @@
             <div class="c-panel">
                 <div class="c-panel-header">
                     <div class="c-panel-icon">
-                        {% icon name="plug" classname="..." title="..." %}
+                        {% icon name="puzzle-piece" %}
                     </div>
                     <div class="c-panel-title">
                         {{ item.plugin.name }}
@@ -78,7 +82,8 @@
                         </div>
                     </div>
                     <div class="c-panel-link">
-                        <a href="{{ item.connection.index_url }}" class="button bicolor button--icon button-secondary">
+                        <a href="{{ item.connection.index_url }}"
+                           class="button button-small bicolor button--icon button-secondary">
                             <span class="icon-wrapper">
                                 <svg class="icon icon-list-ul icon" aria-hidden="true">
                                     <use href="#icon-list-ul"></use>

--- a/adl/src/adl/core/templates/core/dispatch_channel_list.html
+++ b/adl/src/adl/core/templates/core/dispatch_channel_list.html
@@ -1,3 +1,101 @@
-{% extends "wagtailadmin/generic/index.html" %}
+{% extends "wagtailadmin/generic/base.html" %}
 
-{% load i18n wagtailadmin_tags static %}
+{% load i18n wagtailadmin_tags static wagtailiconchooser_tags %}
+
+
+{% block main_content %}
+    <style>
+        .c-panels-container {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 30px;
+            padding: 16px;
+            margin-top: 40px;
+        }
+
+        .c-panel {
+            display: flex;
+            flex-direction: column;
+            padding: 16px;
+            border-radius: 8px;
+            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1), 0 1px 3px rgba(0, 0, 0, 0.06);
+            min-height: 200px;
+            min-width: 400px;
+        }
+
+        .c-panel-header {
+            display: flex;
+            align-items: center;
+            border-bottom: 1px solid #e4e4e4;
+        }
+
+        .c-panel-icon svg {
+            height: 20px;
+            width: 20px;
+        }
+
+        .c-panel-title {
+            font-size: 1.2em;
+            font-weight: bold;
+            margin-left: 10px;
+        }
+
+        .c-panel-body {
+            display: flex;
+            flex: 1;
+            padding: 16px 0;
+            flex-direction: column;
+            justify-content: center;
+        }
+
+        .c-panel-meta {
+            margin-bottom: 10px;
+        }
+
+        .c-panel-meta-item {
+            display: flex;
+            align-items: center;
+            gap: 5px;
+        }
+
+        .c-panel-link {
+            margin-top: 10px;
+        }
+
+    </style>
+
+    <div class="c-panels-container">
+        {% for item in dispatch_channels.values %}
+            <div class="c-panel">
+                <div class="c-panel-header">
+                    <div class="c-panel-icon">
+                        {% icon name="resubmit" %}
+                    </div>
+                    <div class="c-panel-title">
+                        {{ item.name }}
+                    </div>
+                </div>
+                <div class="c-panel-body">
+                    <div class="c-panel-meta">
+                        <div class="c-panel-meta-item">
+                            <strong>Channels:</strong> {{ item.channels|length }}
+                        </div>
+                    </div>
+                    <div class="c-panel-link">
+                        <a href="{{ item.index_url }}"
+                           class="button button-small bicolor button--icon button-secondary">
+                            <span class="icon-wrapper">
+                                <svg class="icon icon-list-ul icon" aria-hidden="true">
+                                    <use href="#icon-list-ul"></use>
+                                </svg>
+                            </span>
+                            View Channels
+                        </a>
+                    </div>
+                </div>
+            </div>
+        {% endfor %}
+    </div>
+
+{% endblock %}
+

--- a/adl/src/adl/core/templates/core/station_index_table.html
+++ b/adl/src/adl/core/templates/core/station_index_table.html
@@ -1,0 +1,34 @@
+{% load wagtailadmin_tags %}
+
+<table{% include "wagtailadmin/shared/attrs.html" with attrs=table.attrs %}>
+    {% with caption=table.get_caption %}
+        {% if caption %}
+            <caption class="w-sr-only">{{ caption }}</caption>
+        {% endif %}
+    {% endwith %}
+    {% if table.has_column_widths %}
+        {% for column in table.columns.values %}
+            <col {% if column.width %}width="{{ column.width }}"{% endif %}/>
+        {% endfor %}
+    {% endif %}
+    <thead>
+    <tr {% if table.header_row_classname %}class="{{ table.header_row_classname }}"{% endif %}>
+        {% for column in table.columns.values %}
+            {% component column.header %}
+        {% endfor %}
+    </tr>
+    </thead>
+    <tbody>
+    {% for row in table.rows %}
+        <tr{% include "wagtailadmin/shared/attrs.html" with attrs=row.attrs %}>
+            {% for cell in row.values %}
+                {% component cell %}
+            {% endfor %}
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>
+
+
+
+

--- a/adl/src/adl/core/templatetags/adl_tags.py
+++ b/adl/src/adl/core/templatetags/adl_tags.py
@@ -14,3 +14,8 @@ def django_settings(value):
 @register.simple_tag
 def adl_version():
     return __version__
+
+
+@register.filter
+def get_item(dictionary, key):
+    return dictionary.get(key)

--- a/adl/src/adl/core/views.py
+++ b/adl/src/adl/core/views.py
@@ -1,4 +1,5 @@
 import json
+from collections import defaultdict
 
 from django.contrib.gis.geos import Point
 from django.core.cache import cache
@@ -6,12 +7,10 @@ from django.core.paginator import Paginator, InvalidPage
 from django.db import transaction
 from django.shortcuts import render, redirect
 from django.urls import reverse_lazy, reverse
-from django.urls.exceptions import NoReverseMatch
 from django.utils.translation import gettext as _
 from wagtail.admin import messages
-from wagtail.admin.ui.tables import Column, Table, TitleColumn, ButtonsColumnMixin
-from wagtail.admin.widgets import HeaderButton, ListingButton
-from wagtail_modeladmin.helpers import AdminURLHelper
+from wagtail.admin.ui.tables import Table, TitleColumn
+from wagtail.admin.widgets import HeaderButton
 
 from .constants import OSCAR_SURFACE_REQUIRED_CSV_COLUMNS, PREDEFINED_DATA_PARAMETERS
 from .forms import StationLoaderForm, OSCARStationImportForm, CreatePredefinedDataParametersForm
@@ -22,19 +21,19 @@ from .models import (
     NetworkConnection,
     DispatchChannel, DataParameter, Unit
 )
-from .table import LinkColumnWithIcon
+from .registries import dispatch_channel_viewset_registry, connection_viewset_registry, plugin_registry
 from .utils import (
     get_stations_for_country_live,
     get_stations_for_country_local,
     get_wigos_id_parts,
     extract_digits,
     get_all_child_models,
-    get_child_model_by_name, get_model_by_string_label
+    get_child_model_by_name
 )
 
 
 def load_stations_csv(request):
-    from .wagtail_hooks import StationViewSet
+    from .viewsets import StationViewSet
     stations_url = StationViewSet().menu_url
     
     template_name = "adl/load_stations_csv.html"
@@ -123,7 +122,7 @@ def load_stations_oscar(request):
     use_local_copy = request.GET.get("use_local", '').lower()
     use_local_copy = use_local_copy in ['1', 'true']
     
-    from .wagtail_hooks import StationViewSet
+    from .viewsets import StationViewSet
     stations_url = StationViewSet().menu_url
     station_edit_url_name = StationViewSet().get_url_name("edit")
     
@@ -207,7 +206,7 @@ def load_stations_oscar(request):
 
 
 def import_oscar_station(request, wigos_id):
-    from .wagtail_hooks import StationViewSet
+    from .viewsets import StationViewSet
     
     use_local_copy = request.GET.get("use_local", '').lower()
     use_local_copy = use_local_copy in ['1', 'true']
@@ -350,101 +349,45 @@ def import_oscar_station(request, wigos_id):
     return render(request, template_name=template_name, context=context)
 
 
+def get_index_url_for_connection(connection):
+    model_cls = get_child_model_by_name(NetworkConnection, connection._meta.model_name)
+    viewset = connection_viewset_registry.get(model_cls._meta.model_name)
+    return reverse(viewset.get_url_name("index"))
+
+
 def connections_list(request):
-    queryset = NetworkConnection.objects.all().order_by("name")
+    connections = NetworkConnection.objects.all().order_by("name")
     
-    breadcrumbs_items = [
-        {"url": reverse_lazy("wagtailadmin_home"), "label": _("Home")},
-        {"url": "", "label": _("Network Connections")},
-    ]
+    # Group connections by plugin
+    grouped_connections = defaultdict(list)
+    for conn in connections:
+        grouped_connections[conn.plugin].append(conn)
     
-    # Get search parameters from the query string.
-    try:
-        page_num = int(request.GET.get("p", 0))
-    except ValueError:
-        page_num = 0
-    
-    all_count = queryset.count()
-    result_count = all_count
-    paginator = Paginator(queryset, 20)
-    
-    try:
-        page_obj = paginator.page(page_num + 1)
-    except InvalidPage:
-        page_obj = paginator.page(1)
-    
-    def get_edit_url(instance):
-        model_cls = instance.__class__
-        if model_cls:
-            url_helper = AdminURLHelper(model_cls)
-            edit_url = url_helper.get_action_url("edit", instance.id)
-            return edit_url
-        
-        return None
-    
-    def get_stations_link_url(instance):
-        model_cls = instance.__class__
-        station_link_url = None
-        
-        if hasattr(instance, "get_station_link_url"):
-            station_link_url = instance.get_station_link_url()
-        else:
-            if hasattr(model_cls, "station_link_model_string_label"):
-                station_link_model = get_model_by_string_label(model_cls.station_link_model_string_label)
-                
-                if station_link_model:
-                    url_helper = AdminURLHelper(station_link_model)
-                    try:
-                        station_link_url = url_helper.index_url
-                    except NoReverseMatch:
-                        pass
-        
-        return station_link_url
-    
-    class ExtraColumnButtons(ButtonsColumnMixin, Column):
-        cell_template_name = "adl/tables/column_cell.html"
-        
-        def get_buttons(self, instance, parent_context):
-            extra_links = []
-            if hasattr(instance, "get_extra_model_admin_links"):
-                links = instance.get_extra_model_admin_links()
-                for link in links:
-                    extra_links.append(
-                        ListingButton(
-                            link.get("label"),
-                            url=link.get("url"),
-                            icon_name=link.get("icon_name", ""),
-                            **link.get("kwargs", {})
-                        )
-                    )
-            return extra_links
-    
-    columns = [
-        TitleColumn("name", label=_("Name"), get_url=get_edit_url),
-        LinkColumnWithIcon("stations_link", label=_("Stations Link"), icon_name="map-pin",
-                           get_url=get_stations_link_url),
-        ExtraColumnButtons("options", label=_("Options"))
-    ]
-    
-    add_url = reverse("connections_add_select")
-    
-    buttons = [
-        HeaderButton(
-            label=_('Add Connection'),
-            url=add_url,
-            icon_name="plus",
-        ),
-    ]
+    # Prepare data for each plugin group
+    data = []
+    for plugin, conns in grouped_connections.items():
+        plugin_obj = plugin_registry.get(plugin)
+        data.append({
+            "plugin": {"name": plugin_obj.label},
+            "connection": {
+                "index_url": get_index_url_for_connection(conns[0]),
+                "count": len(conns),
+            },
+        })
     
     context = {
-        "breadcrumbs_items": breadcrumbs_items,
-        "all_count": all_count,
-        "result_count": result_count,
-        "paginator": paginator,
-        "page_obj": page_obj,
-        "object_list": page_obj.object_list,
-        "header_buttons": buttons,
-        "table": Table(columns, page_obj.object_list),
+        "breadcrumbs_items": [
+            {"url": reverse_lazy("wagtailadmin_home"), "label": _("Home")},
+            {"url": "", "label": _("Network Connections")},
+        ],
+        "header_buttons": [
+            HeaderButton(
+                label=_('Add Connection'),
+                url=reverse("connections_add_select"),
+                icon_name="plus",
+            ),
+        ],
+        "plugin_connections": data,  # Optional: pass it to template if needed
     }
     
     return render(request, "core/connection_list.html", context)
@@ -477,12 +420,11 @@ def connection_add_select(request):
     
     def get_url(instance):
         model_cls = get_child_model_by_name(NetworkConnection, instance["name"])
-        if model_cls:
-            url_helper = AdminURLHelper(model_cls)
-            create_url = url_helper.get_action_url("create")
-            return create_url
+        model_name = model_cls._meta.model_name
         
-        return None
+        viewset = connection_viewset_registry.get(model_name)
+        create_url = reverse(viewset.get_url_name("add"))
+        return create_url
     
     columns = [
         TitleColumn("verbose_name", label=_("Name"), get_url=get_url),
@@ -526,12 +468,10 @@ def dispatch_channels_list(request):
     
     def get_edit_url(instance):
         model_cls = instance.__class__
-        if model_cls:
-            url_helper = AdminURLHelper(model_cls)
-            edit_url = url_helper.get_action_url("edit", instance.id)
-            return edit_url
-        
-        return None
+        model_name = model_cls._meta.model_name
+        viewset = dispatch_channel_viewset_registry.get(model_name)
+        edit_url = reverse(viewset.get_url_name("edit"), args=[instance.id])
+        return edit_url
     
     columns = [
         TitleColumn("name", label=_("Name"), get_url=get_edit_url),
@@ -590,12 +530,11 @@ def dispatch_channel_add_select(request):
     
     def get_url(instance):
         model_cls = get_child_model_by_name(DispatchChannel, instance["name"])
-        if model_cls:
-            url_helper = AdminURLHelper(model_cls)
-            create_url = url_helper.get_action_url("create")
-            return create_url
+        model_name = model_cls._meta.model_name
         
-        return None
+        viewset = dispatch_channel_viewset_registry.get(model_name)
+        create_url = reverse(viewset.get_url_name("add"))
+        return create_url
     
     columns = [
         TitleColumn("name", label=_("Name"), get_url=get_url),
@@ -615,7 +554,7 @@ def dispatch_channel_add_select(request):
 
 
 def create_predefined_data_parameters(request):
-    from .wagtail_hooks import DataParameterViewSet
+    from .viewsets import DataParameterViewSet
     
     form = CreatePredefinedDataParametersForm()
     

--- a/adl/src/adl/core/views.py
+++ b/adl/src/adl/core/views.py
@@ -630,7 +630,7 @@ def create_predefined_data_parameters(request):
                     for parameter in PREDEFINED_DATA_PARAMETERS:
                         unit = parameter.get("unit")
                         unit_symbol = unit.get("symbol")
-                        conversion_context = unit.get("conversion_context")
+                        conversion_context = parameter.get("conversion_context")
                         wis2box_aws_csv_template_unit = parameter.get("wis2box_aws_csv_template_unit")
                         
                         # get or create unit

--- a/adl/src/adl/core/viewsets.py
+++ b/adl/src/adl/core/viewsets.py
@@ -1,6 +1,7 @@
 from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
+from wagtail.admin.ui.tables import Table
 from wagtail.admin.viewsets.chooser import ChooserViewSet
 from wagtail.admin.viewsets.model import ModelViewSet
 from wagtail.admin.widgets import HeaderButton
@@ -48,6 +49,11 @@ class StationIndexView(IndexView):
         ])
         
         return buttons
+    
+    def get_table_kwargs(self):
+        table_kwargs = super().get_table_kwargs()
+        # table_kwargs["template_name"] = "core/station_index_table.html"
+        return table_kwargs
 
 
 class StationViewSet(ModelViewSet):

--- a/adl/src/adl/core/viewsets.py
+++ b/adl/src/adl/core/viewsets.py
@@ -1,0 +1,147 @@
+from django.urls import reverse
+from django.utils.functional import cached_property
+from django.utils.translation import gettext_lazy as _
+from wagtail.admin.viewsets.chooser import ChooserViewSet
+from wagtail.admin.viewsets.model import ModelViewSet
+from wagtail.admin.widgets import HeaderButton
+from wagtail.snippets.views.snippets import IndexView
+
+from .constants import PREDEFINED_DATA_PARAMETERS
+from .models import (
+    Network,
+    Station,
+    DataParameter,
+    Unit
+)
+
+
+class NetworkViewSet(ModelViewSet):
+    model = Network
+    base_url_path = "network"
+    icon = "circle-nodes"
+    add_to_admin_menu = True
+    menu_order = 100
+
+
+class NetworkChooserViewSet(ChooserViewSet):
+    model = Network
+    icon = "circle-nodes"
+    choose_one_text = "Choose Network"
+    choose_another_text = "Choose different Network"
+    edit_item_text = "Edit this Network"
+
+
+class StationIndexView(IndexView):
+    list_display = ["name", "network", "station_id", "wigos_id"]
+    list_filter = ["network", ]
+    
+    @cached_property
+    def header_buttons(self):
+        buttons = super().header_buttons
+        
+        buttons.extend([
+            HeaderButton(
+                label=_('Load Stations from OSCAR Surface'),
+                url=reverse("load_stations_oscar"),
+                icon_name="plus",
+            ),
+        ])
+        
+        return buttons
+
+
+class StationViewSet(ModelViewSet):
+    model = Station
+    index_view_class = StationIndexView
+    icon = "map-pin"
+    add_to_admin_menu = True
+    menu_order = 200
+    list_per_page = 50
+
+
+class StationChooserViewSet(ChooserViewSet):
+    model = Station
+    icon = "map-pin"
+    choose_one_text = "Choose Station"
+    choose_another_text = "Choose different Station"
+    edit_item_text = "Edit this Station"
+    list_per_page = 50
+
+
+class UnitViewSet(ModelViewSet):
+    model = Unit
+    icon = "list-ul"
+    add_to_settings_menu = True
+    list_display = ["name", "symbol", "get_registry_unit"]
+    menu_order = 700
+    list_per_page = 50
+
+
+class UnitChooserViewSet(ChooserViewSet):
+    model = Unit
+    icon = "list-ul"
+    choose_one_text = "Choose Unit"
+    choose_another_text = "Choose different Unit"
+    edit_item_text = "Edit this unit"
+    per_page = 50
+
+
+class DataParameterIndexView(IndexView):
+    @cached_property
+    def header_buttons(self):
+        buttons = super().header_buttons
+        
+        has_existing_objects = self.get_queryset().exists()
+        
+        if not has_existing_objects:
+            buttons.extend([
+                HeaderButton(
+                    label=_('Create from Predefined Data Parameters'),
+                    url=reverse("create_predefined_data_parameters"),
+                    icon_name="plus",
+                ),
+            ])
+        
+        return buttons
+    
+    def get_context_data(self):
+        context = super().get_context_data()
+        context["create_predefined_data_parameters_url"] = reverse("create_predefined_data_parameters")
+        
+        items_count = context.get("items_count")
+        
+        if items_count == 0:
+            context["predefined_data_parameters"] = PREDEFINED_DATA_PARAMETERS
+        
+        return context
+
+
+class DataParameterViewSet(ModelViewSet):
+    model = DataParameter
+    index_results_template_name = "core/data_parameter_index_results.html"
+    index_view_class = DataParameterIndexView
+    add_to_settings_menu = True
+    menu_order = 800
+    icon = "form"
+    list_per_page = 50
+
+
+class DataParameterChooserViewSet(ChooserViewSet):
+    model = DataParameter
+    icon = "form"
+    choose_one_text = "Choose DataParameter"
+    choose_another_text = "Choose different DataParameter"
+    edit_item_text = "Edit this DataParameter"
+    per_page = 50
+
+
+admin_viewsets = [
+    NetworkViewSet("network"),
+    NetworkChooserViewSet("network_chooser"),
+    StationViewSet("station"),
+    StationChooserViewSet("station_chooser"),
+    UnitViewSet("unit"),
+    UnitChooserViewSet("unit_chooser"),
+    DataParameterViewSet("data_parameter"),
+    DataParameterChooserViewSet("data_parameter_chooser"),
+]

--- a/adl/src/adl/core/wagtail_hooks.py
+++ b/adl/src/adl/core/wagtail_hooks.py
@@ -131,6 +131,7 @@ def register_icons(icons):
         'wagtailfontawesomesvg/solid/hourglass-end.svg',
         'wagtailfontawesomesvg/solid/hourglass-half.svg',
         'wagtailfontawesomesvg/solid/paper-plane.svg',
+        'wagtailfontawesomesvg/solid/puzzle-piece.svg',
     ]
 
 

--- a/adl/src/adl/version.py
+++ b/adl/src/adl/version.py
@@ -1,6 +1,6 @@
 # major.minor.patch.release.number
 # release must be one of alpha, beta, rc, or final
-VERSION = (0, 2, 1, "final", 0)
+VERSION = (0, 3, 0, "final", 0)
 
 
 def get_semver_version(version):


### PR DESCRIPTION
- This PR brings changes to move from using the external [Wagtail Model Admin](https://docs.wagtail.org/en/v2.16.3/reference/contrib/modeladmin/index.html) Package to using Wagtail Viewsets for connecting plugins to the Admin
- Also improve the UI for Connections and Dispatch Channels index views