### PR TITLE
fix: resolve static/media/backup roots to mounted volumes and clear s…

### DIFF
--- a/adl/src/adl/config/settings/base.py
+++ b/adl/src/adl/config/settings/base.py
@@ -235,10 +235,10 @@ STATICFILES_DIRS = [
     os.path.join(PROJECT_DIR, "static"),
 ]
 
-STATIC_ROOT = os.path.join(BASE_DIR, "static")
+STATIC_ROOT = env.str("STATIC_ROOT", os.path.join(BASE_DIR, "static"))
 STATIC_URL = "/static/"
 
-MEDIA_ROOT = os.path.join(BASE_DIR, "media")
+MEDIA_ROOT = env.str("MEDIA_ROOT", os.path.join(BASE_DIR, "media"))
 MEDIA_URL = "/media/"
 
 # Default storage settings, with the staticfiles storage updated.
@@ -420,7 +420,9 @@ SPECTACULAR_SETTINGS = {
 }
 
 DBBACKUP_STORAGE = 'django.core.files.storage.FileSystemStorage'
-DBBACKUP_STORAGE_OPTIONS = {'location': os.path.join(BASE_DIR, "backup")}
+DBBACKUP_STORAGE_OPTIONS = {
+    'location': env.str("BACKUP_ROOT", os.path.join(BASE_DIR, "backup"))
+}
 DBBACKUP_CLEANUP_KEEP_MEDIA = 1
 DBBACKUP_CLEANUP_KEEP = 1
 DBBACKUP_CONNECTORS = {

--- a/adl/src/adl/version.py
+++ b/adl/src/adl/version.py
@@ -1,6 +1,6 @@
 # major.minor.patch.release.number
 # release must be one of alpha, beta, rc, or final
-VERSION = (0, 8, 0, "final", 0)
+VERSION = (0, 8, 1, "final", 0)
 
 
 def get_semver_version(version):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,9 @@ x-backend-variables: &backend-variables
   ADL_PLUGIN_SETUP_ALREADY_RUN: ${ADL_PLUGIN_SETUP_ALREADY_RUN:-}
   ADL_DISABLE_PLUGIN_INSTALL_ON_STARTUP: ${ADL_DISABLE_PLUGIN_INSTALL_ON_STARTUP:-}
   SMARTMET_PARAMETER_NAMES: ${SMARTMET_PARAMETER_NAMES:-}
+  STATIC_ROOT: /adl/app/src/adl/static
+  MEDIA_ROOT: /adl/app/src/adl/media
+  BACKUP_ROOT: /adl/app/src/adl/backup
 
 services:
   adl_db:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -50,8 +50,8 @@ run_setup_commands_if_configured(){
   fi
 
   if [ "$COLLECT_STATICFILES_ON_STARTUP" = "true" ] ; then
-    echo "python /adl/app/src/adl/manage.py collectstatic --noinput"
-    /adl/app/src/adl/manage.py collectstatic --noinput
+    echo "python /adl/app/src/adl/manage.py collectstatic --noinput --clear"
+    /adl/app/src/adl/manage.py collectstatic --noinput --clear
   fi
 }
 


### PR DESCRIPTION
…tale assets on collectstatic

STATIC_ROOT, MEDIA_ROOT, and DBBACKUP_STORAGE_OPTIONS were resolving to the installed package directory under site-packages instead of the bind-mounted volume paths, causing collectstatic output, uploaded media, and backups to be lost on container restart.

- Added STATIC_ROOT, MEDIA_ROOT, and BACKUP_ROOT env vars in docker-compose.yml pointing to /adl/app/src/adl/{static,media,backup}
- Updated base.py to read BACKUP_ROOT for DBBACKUP_STORAGE_OPTIONS
- Added --clear flag to collectstatic in docker-entrypoint.sh to prevent stale hashed files accumulating on the host volume across upgrades