### PR TITLE
feat: add dedicated ADL celery queue for ingestion and dispatch tasks

### DIFF
--- a/adl/src/adl/config/settings/base.py
+++ b/adl/src/adl/config/settings/base.py
@@ -301,6 +301,12 @@ CELERY_SINGLETON_BACKEND_CLASS = (
 CELERY_RESULT_BACKEND = 'django-db'
 CELERY_RESULT_EXTENDED = True
 
+CELERY_TASK_ROUTES = {
+    'adl.core.tasks.run_network_plugin': {'queue': 'adl'},
+    'adl.core.tasks.process_station_link_batch': {'queue': 'adl'},
+    'adl.core.tasks.perform_channel_dispatch': {'queue': 'adl'},
+}
+
 CACHES = {
     "default": {
         "BACKEND": "django_redis.cache.RedisCache",

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -12,10 +12,19 @@ services:
     ports:
       - "8000:8000"
 
-  adl_celery_worker:
+  adl_celery_worker_default:
     build:
       target: dev
     command: celery-worker-dev
+    environment:
+      DEBUG: "True"
+    volumes:
+      - ./adl:/adl/app
+
+  adl_celery_worker_adl:
+    build:
+      target: dev
+    command: celery-worker-adl
     environment:
       DEBUG: "True"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,8 +88,8 @@ services:
       - ${ADL_MEDIA_VOLUME:-./docker/media}:/adl/app/src/adl/media
       - ${ADL_BACKUP_VOLUME:-./docker/backup}:/adl/app/src/adl/backup
 
-  adl_celery_worker:
-    container_name: adl_celery_worker
+  adl_celery_worker_default:
+    container_name: adl_celery_worker_default
     image: adl
     build:
       context: .
@@ -102,12 +102,40 @@ services:
         - ADL_PLUGIN_GIT_REPOS=${ADL_PLUGIN_GIT_REPOS}
     restart: unless-stopped
     init: true
-    command: celery-worker
+    command: celery-worker-default
     environment:
       <<: *backend-variables
       WAIT_HOSTS: adl_db:5432,adl_redis:6379,adl:8000
       ADL_DISABLE_PLUGIN_INSTALL_ON_STARTUP: "true"
       ADL_CELERY_WORKER_CONCURRENCY: ${ADL_CELERY_WORKER_CONCURRENCY:-1}
+    depends_on:
+      - adl_db
+      - adl_redis
+    volumes:
+      - ${ADL_STATIC_VOLUME:-./docker/static}:/adl/app/src/adl/static
+      - ${ADL_MEDIA_VOLUME:-./docker/media}:/adl/app/src/adl/media
+      - ${ADL_BACKUP_VOLUME:-./docker/backup}:/adl/app/src/adl/backup
+
+  adl_celery_worker_adl:
+    container_name: adl_celery_worker_adl
+    image: adl
+    build:
+      context: .
+      dockerfile: ${ADL_DOCKERFILE:-Dockerfile}
+      target: prod
+      args:
+        - UID=${UID}
+        - GID=${GID}
+        - DOCKER_COMPOSE_WAIT_PLATFORM_SUFFIX=${DOCKER_COMPOSE_WAIT_PLATFORM_SUFFIX:-}
+        - ADL_PLUGIN_GIT_REPOS=${ADL_PLUGIN_GIT_REPOS}
+    restart: unless-stopped
+    init: true
+    command: celery-worker-adl
+    environment:
+      <<: *backend-variables
+      WAIT_HOSTS: adl_db:5432,adl_redis:6379,adl:8000
+      ADL_DISABLE_PLUGIN_INSTALL_ON_STARTUP: "true"
+      ADL_CELERY_WORKER_CONCURRENCY: ${ADL_CELERY_WORKER_ADL_CONCURRENCY:-2}
     depends_on:
       - adl_db
       - adl_redis

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -30,7 +30,8 @@ gunicorn-wsgi       : Start ADL using a prod ready gunicorn server:
                          * Waits for the database and Redis to be available first.
                          * Automatically migrates the database on startup.
                          * Binds to 0.0.0.0
-celery-worker       : Start the Celery worker
+celery-worker-default: Start the Celery worker (default queue)
+celery-worker-adl   : Start the Celery worker for the ADL ingestion/dispatch queue
 celery-worker-dev   : Start the Celery worker with auto-reload on code changes
                       (requires the dev build target)
 celery-beat         : Start the Celery beat scheduler
@@ -138,8 +139,11 @@ manage)
 shell)
     exec python3 /adl/app/src/adl/manage.py shell
     ;;
-celery-worker)
+celery-worker-default)
     start_celery_worker -Q celery -n default-worker@%h "${@:2}"
+    ;;
+celery-worker-adl)
+    start_celery_worker -Q adl -n adl-worker@%h "${@:2}"
     ;;
 celery-worker-dev)
     startup_plugin_setup


### PR DESCRIPTION
## Summary

- Routes `run_network_plugin`, `process_station_link_batch`, and `perform_channel_dispatch` to a dedicated `adl` Celery queue via `CELERY_TASK_ROUTES` in settings
- Adds `adl_celery_worker_adl` service (prod + dev) that listens exclusively on the `adl` queue
- Renames the existing worker to `adl_celery_worker_default` / `celery-worker-default` for clarity
- ADL worker concurrency is independently tunable via `ADL_CELERY_WORKER_ADL_CONCURRENCY` (defaults to 2)

## Test plan

- [ ] Build and start the stack — confirm both `adl_celery_worker_default` and `adl_celery_worker_adl` containers start cleanly
- [ ] Trigger a network plugin run and confirm the task is picked up by `adl_celery_worker_adl`, not the default worker
- [ ] Trigger a dispatch channel and confirm it routes to the `adl` queue worker
- [ ] Confirm background tasks (e.g. Wagtail, backup) still run on the default worker

🤖 Generated with [Claude Code](https://claude.com/claude-code)