### PR TITLE
fix: explicitly route ADL periodic tasks to the adl queue

### DIFF
--- a/adl/src/adl/core/tasks.py
+++ b/adl/src/adl/core/tasks.py
@@ -84,7 +84,7 @@ def run_network_plugin(self, network_id):
         log.info("Spawning batch %d with %d station links: %s",
                  batch_count, len(batch_list), batch_list)
         
-        task = process_station_link_batch.delay(network_id, batch_list)
+        task = process_station_link_batch.apply_async(args=[network_id, batch_list], queue='adl')
         
         spawned_tasks.append(task.id)
     
@@ -237,6 +237,7 @@ def create_or_update_network_plugin_periodic_tasks(network_connection):
             'task': sig.name,
             'args': json.dumps([network_connection.id]),
             'enabled': enabled,
+            'queue': 'adl',
         }
     )
 
@@ -283,6 +284,7 @@ def create_or_update_dispatch_channel_periodic_tasks(dispatch_channel):
             'task': sig.name,
             'args': json.dumps([dispatch_channel.id]),
             'enabled': enabled,
+            'queue': 'adl',
         }
     )
 


### PR DESCRIPTION
## Summary

`CELERY_TASK_ROUTES` alone does not affect `django-celery-beat` periodic tasks. Celery-beat dispatches using the `queue` field stored in the `PeriodicTask` database record — if that field is unset, tasks fall through to the default worker regardless of routing config.

- Set `queue='adl'` directly in `PeriodicTask.objects.update_or_create` for both `run_network_plugin` and `perform_channel_dispatch` periodic tasks
- Change `process_station_link_batch.delay()` to `apply_async(queue='adl')` so subtasks spawned at runtime also land on the ADL worker

## Test plan

- [ ] Restart the stack and confirm `run_network_plugin` and `perform_channel_dispatch` are picked up by `adl_celery_worker_adl`, not `adl_celery_worker_default`
- [ ] For existing deployments: re-save a `NetworkConnection` and a `DispatchChannel` in the admin to trigger `update_or_create` and backfill `queue='adl'` on existing `PeriodicTask` records

🤖 Generated with [Claude Code](https://claude.com/claude-code)