### PR TITLE
feat: fan-out dispatch channel to per-station subtasks

### DIFF
--- a/adl/src/adl/config/settings/base.py
+++ b/adl/src/adl/config/settings/base.py
@@ -305,6 +305,7 @@ CELERY_TASK_ROUTES = {
     'adl.core.tasks.run_network_plugin': {'queue': 'adl'},
     'adl.core.tasks.process_station_link_batch': {'queue': 'adl'},
     'adl.core.tasks.perform_channel_dispatch': {'queue': 'adl'},
+    'adl.core.tasks.dispatch_station': {'queue': 'adl'},
 }
 
 CACHES = {

--- a/adl/src/adl/core/dispatchers/__init__.py
+++ b/adl/src/adl/core/dispatchers/__init__.py
@@ -63,6 +63,60 @@ def get_station_channel_records(dispatch_channel, station_id, connection_id):
     return obs_records.order_by(time_field)
 
 
+def get_station_dispatch_records(dispatch_channel, station_link):
+    """Fetch and format dispatch records for a single station link."""
+    parameter_mappings = dispatch_channel.get_parameter_mappings()
+    if not parameter_mappings:
+        return []
+
+    parameter_mappings_ids = set(parameter_mappings.values_list("parameter_id", flat=True))
+    send_agg_data = dispatch_channel.send_aggregated_data
+
+    parameter_channel_mapping = {
+        pm.parameter_id: {
+            "channel_parameter": pm.channel_parameter,
+            "adl_parameter": pm.parameter,
+            "value_field": "value" if not send_agg_data else pm.aggregation_measure,
+            "channel_unit": pm.channel_unit,
+        }
+        for pm in parameter_mappings
+    }
+
+    station_channel_records = get_station_channel_records(
+        dispatch_channel,
+        station_link.station_id,
+        station_link.network_connection_id,
+    )
+
+    by_time = {}
+    for obs in station_channel_records:
+        if obs.parameter_id not in parameter_mappings_ids:
+            continue
+        if obs.time not in by_time:
+            by_time[obs.time] = {"wigos_id": station_link.station.wigos_id, "observations": []}
+        by_time[obs.time]["observations"].append(obs)
+
+    records = []
+    for t, station_record in by_time.items():
+        data_values = {}
+        for obs in station_record["observations"]:
+            mapping = parameter_channel_mapping[obs.parameter_id]
+            data_value = getattr(obs, mapping["value_field"])
+            channel_unit = mapping["channel_unit"]
+            if channel_unit != obs.parameter.unit:
+                data_value = mapping["adl_parameter"].convert_value_to_units(data_value, channel_unit)
+            data_values[mapping["channel_parameter"]] = data_value
+
+        records.append({
+            "station_id": station_link.station_id,
+            "wigos_id": station_record["wigos_id"],
+            "timestamp": t,
+            "values": data_values,
+        })
+
+    return records
+
+
 def get_dispatch_channel_data(dispatch_channel, station_link_ids=None):
     channel_name = dispatch_channel.name
     logger.info(f"[DISPATCH] Getting dispatch data for channel '{channel_name}'")

--- a/adl/src/adl/core/tasks.py
+++ b/adl/src/adl/core/tasks.py
@@ -10,8 +10,11 @@ from django.core.cache import cache
 from django_celery_beat.models import IntervalSchedule, PeriodicTask
 from more_itertools import chunked
 
+from django.utils import timezone as dj_timezone
+
 from adl.config.celery import app
-from .dispatchers import run_dispatch_channel
+from adl.monitoring.models import StationLinkActivityLog
+from .dispatchers import get_station_dispatch_records
 from .logging import TaskLogger
 from .utils import get_object_or_none
 
@@ -246,22 +249,100 @@ def update_network_plugin_periodic_task(sender, instance, **kwargs):
     create_or_update_network_plugin_periodic_tasks(instance)
 
 
-@app.task(
-    base=Singleton,
-    bind=True
-)
+@app.task(base=Singleton, bind=True)
 def perform_channel_dispatch(self, channel_id, station_link_ids=None):
     from .models import DispatchChannel
     channel = get_object_or_none(DispatchChannel, id=channel_id)
-    
+
     if not channel:
         message = f"Dispatch channel with id {channel_id} does not exist"
         logger.error(message)
         raise ValueError(message)
-    
-    num_of_sent_records = run_dispatch_channel(channel.id, station_link_ids=station_link_ids)
-    
-    return {"records_count": num_of_sent_records}
+
+    eligible = channel.stations_allowed_to_send()
+    if station_link_ids:
+        eligible = eligible.filter(id__in=station_link_ids)
+
+    ids = list(eligible.values_list("id", flat=True))
+
+    for station_link_id in ids:
+        dispatch_station.apply_async(args=[channel_id, station_link_id], queue="adl")
+
+    logger.info("[DISPATCH] Channel %s: spawned %d station dispatch tasks", channel.name, len(ids))
+    return {"stations_dispatched": len(ids)}
+
+
+@shared_task(bind=True, name="adl.core.tasks.dispatch_station")
+def dispatch_station(self, channel_id, station_link_id):
+    from .models import DispatchChannel, StationChannelDispatchStatus, StationLink
+
+    channel = get_object_or_none(DispatchChannel, id=channel_id)
+    station_link = get_object_or_none(StationLink, id=station_link_id)
+
+    if not channel or not station_link:
+        logger.error("[DISPATCH] dispatch_station: channel %s or station_link %s not found",
+                     channel_id, station_link_id)
+        return
+
+    start = time.monotonic()
+    log = StationLinkActivityLog.objects.create(
+        time=dj_timezone.now(),
+        station_link=station_link,
+        direction="push",
+        dispatch_channel=channel,
+    )
+
+    try:
+        data_records = get_station_dispatch_records(channel, station_link)
+
+        if not data_records:
+            log.success = True
+            log.records_count = 0
+            log.message = "No data records to send"
+            log.status = StationLinkActivityLog.ActivityStatus.COMPLETED
+            return {"records_sent": 0}
+
+        num_sent, last_sent_obs_time = channel.send_station_data(station_link, data_records)
+
+        previous_sent_obs_time = None
+        if num_sent > 0 and last_sent_obs_time:
+            status = get_object_or_none(
+                StationChannelDispatchStatus,
+                channel_id=channel_id,
+                station_id=station_link.station_id,
+            )
+            if status:
+                previous_sent_obs_time = status.last_sent_obs_time
+                status.last_sent_obs_time = last_sent_obs_time
+                status.save()
+            else:
+                StationChannelDispatchStatus.objects.create(
+                    channel_id=channel_id,
+                    station_id=station_link.station_id,
+                    last_sent_obs_time=last_sent_obs_time,
+                )
+
+        log.success = True
+        log.records_count = num_sent
+        if previous_sent_obs_time:
+            log.obs_start_time = previous_sent_obs_time
+        if last_sent_obs_time:
+            log.obs_end_time = last_sent_obs_time
+        log.status = StationLinkActivityLog.ActivityStatus.COMPLETED
+        log.message = f"Sent {num_sent} records successfully."
+        return {"records_sent": num_sent}
+
+    except Exception as e:
+        log.success = False
+        log.message = str(e)
+        log.status = StationLinkActivityLog.ActivityStatus.FAILED
+        logger.error("[DISPATCH] Error dispatching station %s on channel %s: %s",
+                     station_link, channel.name, e)
+        raise
+
+    finally:
+        log.duration_ms = (time.monotonic() - start) * 1000
+        log.save()
 
 
 def create_or_update_dispatch_channel_periodic_tasks(dispatch_channel):


### PR DESCRIPTION
## Summary

- `perform_channel_dispatch` is now a thin coordinator: fetches eligible station link IDs and fans out one `dispatch_station` subtask per station on the `adl` queue
- New `dispatch_station` task owns the full lifecycle for one station: fetch records → send → update `StationChannelDispatchStatus` → write `StationLinkActivityLog`
- New `get_station_dispatch_records(channel, station_link)` in `dispatchers/__init__.py` — single-station focused query + transformation, replaces the all-stations `get_dispatch_channel_data` call in the hot path
- `dispatch_station` added to `CELERY_TASK_ROUTES` so subtasks always land on the `adl` worker

## Why

Previously a single task loaded all station records into memory and processed stations serially. With many stations and large datasets this caused high memory usage and long wall-clock dispatch times.

With this change, stations run in parallel bounded by worker concurrency (2 workers × 2 concurrency = 4 simultaneous dispatches), and each worker holds only one station's records in memory at a time.

## Test plan

- [ ] Trigger a dispatch channel with multiple stations — confirm one `dispatch_station` task is queued per station on the `adl` worker
- [ ] Confirm `StationChannelDispatchStatus` and `StationLinkActivityLog` are still written correctly per station
- [ ] Confirm the `station_link_ids` filter on `perform_channel_dispatch` still restricts which stations are fanned out

🤖 Generated with [Claude Code](https://claude.com/claude-code)