### PR TITLE
fix: disable Wagtail reference index on ObservationRecord

### DIFF
--- a/adl/src/adl/core/models.py
+++ b/adl/src/adl/core/models.py
@@ -751,6 +751,7 @@ class QCBits(IntFlag):
 
 @register_snippet
 class ObservationRecord(TimescaleModel, ClusterableModel):
+    wagtail_reference_index_ignore = True
     """
     The atomic unit of stored observation data in ADL.
     


### PR DESCRIPTION
ObservationRecord is saved in high volume during ingestion, causing update_reference_index_task to run synchronously on every save. Since ObservationRecord is not Wagtail content, reference tracking adds unnecessary overhead with no benefit.