### PR TITLE
Dispatch: stale-log sweeper marks orphaned 'started' activity logs as failed

### DIFF
--- a/adl/src/adl/config/settings/base.py
+++ b/adl/src/adl/config/settings/base.py
@@ -306,6 +306,7 @@ CELERY_TASK_ROUTES = {
     'adl.core.tasks.process_station_link_batch': {'queue': 'adl'},
     'adl.core.tasks.perform_channel_dispatch': {'queue': 'adl'},
     'adl.core.tasks.dispatch_station': {'queue': 'adl'},
+    'adl.core.tasks.sweep_stale_dispatch_logs': {'queue': 'adl'},
 }
 
 CACHES = {

--- a/adl/src/adl/core/tasks.py
+++ b/adl/src/adl/core/tasks.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import time
+from datetime import timedelta
 
 from celery import shared_task
 from celery.exceptions import SoftTimeLimitExceeded
@@ -49,6 +50,11 @@ def setup_periodic_tasks(sender, **kwargs):
         crontab(hour=0, minute=0),
         run_backup.s(),
         name="run-backup-daily-at-midnight",
+    )
+    sender.add_periodic_task(
+        300.0,
+        sweep_stale_dispatch_logs.s(),
+        name="sweep-stale-dispatch-logs-every-5-minutes",
     )
 
 
@@ -390,6 +396,45 @@ def dispatch_station(self, channel_id, station_link_id):
         cache.delete(lock_key)
         log.duration_ms = (time.monotonic() - start) * 1000
         log.save()
+
+
+@shared_task(name="adl.core.tasks.sweep_stale_dispatch_logs")
+def sweep_stale_dispatch_logs():
+    """
+    Mark push activity logs stranded in STARTED as failed.
+
+    A dispatch that dies with the worker (hard time limit, OOM, container
+    kill) never reaches the code that finalizes its activity log, leaving the
+    row in STARTED forever. Rows older than their channel's dispatch timeout
+    plus the same grace + margin used for the station lock TTL cannot still
+    be running, so they are swept to FAILED.
+    """
+    from .models import DispatchChannel  # noqa: F401  (FK target must be loaded)
+
+    now = dj_timezone.now()
+    swept = 0
+
+    candidates = StationLinkActivityLog.objects.filter(
+        direction="push",
+        status=StationLinkActivityLog.ActivityStatus.STARTED,
+        dispatch_channel__isnull=False,
+    )
+
+    for log in candidates:
+        threshold_seconds = (log.dispatch_channel.dispatch_timeout_seconds
+                             + DISPATCH_TIME_LIMIT_GRACE_SECONDS
+                             + DISPATCH_LOCK_TTL_MARGIN_SECONDS)
+        if log.time < now - timedelta(seconds=threshold_seconds):
+            log.status = StationLinkActivityLog.ActivityStatus.FAILED
+            log.success = False
+            log.message = "Dispatch worker died mid-dispatch (no completion recorded)"
+            log.save(update_fields=["status", "success", "message"])
+            swept += 1
+
+    if swept:
+        logger.warning("[DISPATCH] Swept %d stale dispatch activity log(s) to FAILED", swept)
+
+    return swept
 
 
 def create_or_update_dispatch_channel_periodic_tasks(dispatch_channel):

--- a/adl/src/adl/core/tests/test_dispatch_tasks.py
+++ b/adl/src/adl/core/tests/test_dispatch_tasks.py
@@ -1,12 +1,17 @@
-from datetime import datetime, timezone as py_tz
+from datetime import datetime, timedelta, timezone as py_tz
 from unittest.mock import patch
 
 from celery.exceptions import SoftTimeLimitExceeded
 from django.core.cache import cache
 from django.test import TestCase
+from django.utils import timezone as dj_tz
 
 from adl.core.models import StationChannelDispatchStatus, Wis2BoxUpload
-from adl.core.tasks import dispatch_station, perform_channel_dispatch
+from adl.core.tasks import (
+    dispatch_station,
+    perform_channel_dispatch,
+    sweep_stale_dispatch_logs,
+)
 from adl.monitoring.models import StationLinkActivityLog
 from .factories import StationLinkFactory, Wis2BoxUploadFactory
 
@@ -120,6 +125,70 @@ class DispatchStationLockTests(DispatchTaskTestCase):
             dispatch_station(self.channel.id, self.link.id)
 
         mock_add.assert_called_once_with(self.lock_key, "locked", timeout=390)
+
+
+class SweepStaleDispatchLogsTests(DispatchTaskTestCase):
+    def _make_push_log(self, age_seconds, status=StationLinkActivityLog.ActivityStatus.STARTED,
+                       channel=None):
+        return StationLinkActivityLog.objects.create(
+            time=dj_tz.now() - timedelta(seconds=age_seconds),
+            station_link=self.link,
+            direction="push",
+            dispatch_channel=channel or self.channel,
+            status=status,
+        )
+
+    def test_stale_started_row_swept_to_failed(self):
+        # default channel timeout 300s + 30s grace + 60s margin = 390s threshold
+        log = self._make_push_log(age_seconds=500)
+
+        swept = sweep_stale_dispatch_logs()
+
+        self.assertEqual(swept, 1)
+        log.refresh_from_db()
+        self.assertEqual(log.status, StationLinkActivityLog.ActivityStatus.FAILED)
+        self.assertFalse(log.success)
+        self.assertIn("worker died", log.message)
+
+    def test_fresh_started_row_untouched(self):
+        # under the 390s threshold: may legitimately still be running
+        log = self._make_push_log(age_seconds=100)
+
+        swept = sweep_stale_dispatch_logs()
+
+        self.assertEqual(swept, 0)
+        log.refresh_from_db()
+        self.assertEqual(log.status, StationLinkActivityLog.ActivityStatus.STARTED)
+
+    def test_finished_rows_untouched_regardless_of_age(self):
+        completed = self._make_push_log(
+            age_seconds=10_000, status=StationLinkActivityLog.ActivityStatus.COMPLETED)
+        failed = self._make_push_log(
+            age_seconds=10_000, status=StationLinkActivityLog.ActivityStatus.FAILED)
+
+        swept = sweep_stale_dispatch_logs()
+
+        self.assertEqual(swept, 0)
+        completed.refresh_from_db()
+        failed.refresh_from_db()
+        self.assertEqual(completed.status, StationLinkActivityLog.ActivityStatus.COMPLETED)
+        self.assertEqual(failed.status, StationLinkActivityLog.ActivityStatus.FAILED)
+
+    def test_threshold_is_per_channel_timeout(self):
+        # same age, different channel timeouts: stale for the 30s channel
+        # (threshold 120s), still fresh for the 600s channel (threshold 690s)
+        short_channel = Wis2BoxUploadFactory(dispatch_timeout_seconds=30)
+        long_channel = Wis2BoxUploadFactory(dispatch_timeout_seconds=600)
+        stale_for_short = self._make_push_log(age_seconds=300, channel=short_channel)
+        fresh_for_long = self._make_push_log(age_seconds=300, channel=long_channel)
+
+        swept = sweep_stale_dispatch_logs()
+
+        self.assertEqual(swept, 1)
+        stale_for_short.refresh_from_db()
+        fresh_for_long.refresh_from_db()
+        self.assertEqual(stale_for_short.status, StationLinkActivityLog.ActivityStatus.FAILED)
+        self.assertEqual(fresh_for_long.status, StationLinkActivityLog.ActivityStatus.STARTED)
 
 
 class CoordinatorTaskContractTests(TestCase):


### PR DESCRIPTION
Closes #110. Part of #103.

A dispatch that dies with its worker (hard time limit, OOM, container kill) never finalizes its activity log, leaving the row in STARTED forever and the per-station history lying. A new 5-minute periodic task sweeps push-direction rows stuck in STARTED beyond their channel's dispatch timeout + the same 30s grace + 60s margin used for the station lock TTL — so the sweeper only fires after the lock has provably expired, and one per-channel field drives all three thresholds (no second knob).

- Swept rows become FAILED, success=false, message 'Dispatch worker died mid-dispatch (no completion recorded)'
- Rows younger than the threshold and finished rows are never modified
- Registered on the beat schedule alongside run_backup; routed with the other dispatch tasks

Tests: sweep, fresh-untouched, finished-untouched, per-channel threshold with mixed timeouts. Full suite 28 tests green via `make dev-test`.