### PR TITLE
Dispatch: per-channel admin actions — Dispatch now and Reset

### DIFF
--- a/adl/src/adl/core/tasks.py
+++ b/adl/src/adl/core/tasks.py
@@ -31,6 +31,10 @@ DISPATCH_TIME_LIMIT_GRACE_SECONDS = 30
 DISPATCH_LOCK_TTL_MARGIN_SECONDS = 60
 
 
+def dispatch_station_lock_key(channel_id, station_link_id):
+    return f"lock:dispatch:{channel_id}:{station_link_id}"
+
+
 @app.task(base=Singleton, bind=True)
 def run_backup(self):
     # TODO: defer until we find a fix with timescale db backup
@@ -308,7 +312,7 @@ def dispatch_station(self, channel_id, station_link_id):
                      channel_id, station_link_id)
         return
 
-    lock_key = f"lock:dispatch:{channel_id}:{station_link_id}"
+    lock_key = dispatch_station_lock_key(channel_id, station_link_id)
     lock_ttl = (channel.dispatch_timeout_seconds
                 + DISPATCH_TIME_LIMIT_GRACE_SECONDS
                 + DISPATCH_LOCK_TTL_MARGIN_SECONDS)

--- a/adl/src/adl/core/templates/core/dispatch_channel_station_links.html
+++ b/adl/src/adl/core/templates/core/dispatch_channel_station_links.html
@@ -14,6 +14,18 @@
             </p>
         </div>
 
+        <div style="display:flex; gap:10px; margin:15px 0;">
+            <form method="post" action="{% url 'dispatch_channel_dispatch_now' channel.id %}">
+                {% csrf_token %}
+                <button type="submit" class="button">{% trans "Dispatch now" %}</button>
+            </form>
+            <form method="post" action="{% url 'dispatch_channel_reset' channel.id %}"
+                  onsubmit="return confirm('{% trans 'Clear stale station dispatch locks for this channel and trigger a fresh dispatch?' %}')">
+                {% csrf_token %}
+                <button type="submit" class="button no">{% trans "Reset dispatch" %}</button>
+            </form>
+        </div>
+
         <form method="post" action="?page={{ page_obj.number }}">
             {% csrf_token %}
             {{ form.non_field_errors }}

--- a/adl/src/adl/core/tests/test_dispatch_admin_actions.py
+++ b/adl/src/adl/core/tests/test_dispatch_admin_actions.py
@@ -1,0 +1,100 @@
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from django.test import TestCase
+from django.urls import reverse
+
+from adl.core.tasks import dispatch_station_lock_key
+from .factories import StationLinkFactory, Wis2BoxUploadFactory
+
+
+class DispatchAdminActionTestCase(TestCase):
+    def setUp(self):
+        self.link = StationLinkFactory()
+        self.channel = Wis2BoxUploadFactory()
+        self.channel.network_connections.add(self.link.network_connection)
+        self.user = get_user_model().objects.create_superuser(
+            username="admin", email="admin@example.com", password="test-pass"
+        )
+        self.client.force_login(self.user)
+
+
+class DispatchNowActionTests(DispatchAdminActionTestCase):
+    def test_post_enqueues_channel_dispatch_and_redirects(self):
+        url = reverse("dispatch_channel_dispatch_now", args=[self.channel.id])
+
+        with patch("adl.core.views.perform_channel_dispatch") as mock_task:
+            response = self.client.post(url, HTTP_REFERER="/admin/dispatch-channels/")
+
+        mock_task.delay.assert_called_once_with(self.channel.id)
+        self.assertEqual(response.status_code, 302)
+
+    def test_get_does_not_enqueue(self):
+        url = reverse("dispatch_channel_dispatch_now", args=[self.channel.id])
+
+        with patch("adl.core.views.perform_channel_dispatch") as mock_task:
+            response = self.client.get(url)
+
+        mock_task.delay.assert_not_called()
+        self.assertEqual(response.status_code, 302)
+
+    def test_anonymous_cannot_trigger(self):
+        self.client.logout()
+        url = reverse("dispatch_channel_dispatch_now", args=[self.channel.id])
+
+        with patch("adl.core.views.perform_channel_dispatch") as mock_task:
+            response = self.client.post(url)
+
+        mock_task.delay.assert_not_called()
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("login", response["Location"])
+
+
+class ResetChannelDispatchTests(DispatchAdminActionTestCase):
+    def test_post_clears_only_this_channels_locks_and_enqueues(self):
+        other_link = StationLinkFactory()
+        other_channel = Wis2BoxUploadFactory()
+        other_channel.network_connections.add(other_link.network_connection)
+
+        own_lock = dispatch_station_lock_key(self.channel.id, self.link.id)
+        other_lock = dispatch_station_lock_key(other_channel.id, other_link.id)
+        cache.set(own_lock, "locked", timeout=300)
+        cache.set(other_lock, "locked", timeout=300)
+        self.addCleanup(cache.delete_many, [own_lock, other_lock])
+
+        url = reverse("dispatch_channel_reset", args=[self.channel.id])
+        with patch("adl.core.views.perform_channel_dispatch") as mock_task:
+            response = self.client.post(url, HTTP_REFERER="/admin/dispatch-channels/")
+
+        self.assertIsNone(cache.get(own_lock))  # cleared
+        self.assertEqual(cache.get(other_lock), "locked")  # untouched
+        mock_task.delay.assert_called_once_with(self.channel.id)
+        self.assertEqual(response.status_code, 302)
+
+    def test_anonymous_cannot_reset(self):
+        self.client.logout()
+        own_lock = dispatch_station_lock_key(self.channel.id, self.link.id)
+        cache.set(own_lock, "locked", timeout=300)
+        self.addCleanup(cache.delete, own_lock)
+
+        url = reverse("dispatch_channel_reset", args=[self.channel.id])
+        with patch("adl.core.views.perform_channel_dispatch") as mock_task:
+            response = self.client.post(url)
+
+        self.assertEqual(cache.get(own_lock), "locked")  # untouched
+        mock_task.delay.assert_not_called()
+        self.assertIn("login", response["Location"])
+
+
+class ChannelPageButtonsTests(DispatchAdminActionTestCase):
+    def test_station_links_page_renders_action_buttons(self):
+        url = reverse("dispatch_channel_station_links", args=[self.channel.id])
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Dispatch now")
+        self.assertContains(response, "Reset dispatch")
+        self.assertContains(response, reverse("dispatch_channel_dispatch_now", args=[self.channel.id]))
+        self.assertContains(response, reverse("dispatch_channel_reset", args=[self.channel.id]))

--- a/adl/src/adl/core/views.py
+++ b/adl/src/adl/core/views.py
@@ -54,7 +54,7 @@ from .registries import (
     plugin_registry
 )
 from .table import LinkColumnWithIcon
-from .tasks import process_station_link_batch, perform_channel_dispatch
+from .tasks import process_station_link_batch, perform_channel_dispatch, dispatch_station_lock_key
 from .utils import (
     get_stations_for_country_live,
     get_stations_for_country_local,
@@ -1166,6 +1166,70 @@ def trigger_station_collection(request, station_link_id):
         # Redirect back to the station link detail page
         return redirect(request.META.get('HTTP_REFERER', 'wagtailadmin_home'))
     
+    return redirect('wagtailadmin_home')
+
+
+def trigger_channel_dispatch(request, channel_id):
+    """Manually trigger a dispatch run for all eligible stations on a channel"""
+    if request.method == 'POST':
+        dispatch_channel = get_object_or_404(DispatchChannel, id=channel_id)
+
+        try:
+            perform_channel_dispatch.delay(dispatch_channel.id)
+
+            messages.success(
+                request,
+                _('Dispatch triggered successfully for %(channel)s.') % {
+                    'channel': dispatch_channel.name
+                }
+            )
+        except Exception as e:
+            messages.error(
+                request,
+                _('Failed to trigger dispatch: %(error)s') % {'error': str(e)}
+            )
+
+        return redirect(request.META.get('HTTP_REFERER', 'wagtailadmin_home'))
+
+    return redirect('wagtailadmin_home')
+
+
+def reset_channel_dispatch(request, channel_id):
+    """Clear the channel's per-station dispatch locks and trigger a fresh dispatch"""
+    if request.method == 'POST':
+        dispatch_channel = get_object_or_404(DispatchChannel, id=channel_id)
+
+        try:
+            # All station links on the channel's connections, including ones
+            # currently excluded from dispatch — they may hold stale locks too
+            station_link_ids = list(
+                StationLink.objects.filter(
+                    network_connection__in=dispatch_channel.network_connections.all()
+                ).values_list("id", flat=True)
+            )
+
+            lock_keys = [dispatch_station_lock_key(dispatch_channel.id, sl_id)
+                         for sl_id in station_link_ids]
+            if lock_keys:
+                cache.delete_many(lock_keys)
+
+            perform_channel_dispatch.delay(dispatch_channel.id)
+
+            messages.success(
+                request,
+                _('Dispatch reset for %(channel)s: cleared station locks and '
+                  'triggered a fresh dispatch.') % {
+                    'channel': dispatch_channel.name
+                }
+            )
+        except Exception as e:
+            messages.error(
+                request,
+                _('Failed to reset dispatch: %(error)s') % {'error': str(e)}
+            )
+
+        return redirect(request.META.get('HTTP_REFERER', 'wagtailadmin_home'))
+
     return redirect('wagtailadmin_home')
 
 

--- a/adl/src/adl/core/wagtail_hooks.py
+++ b/adl/src/adl/core/wagtail_hooks.py
@@ -41,6 +41,8 @@ from .views import (
     dispatch_channel_station_links,
     trigger_station_collection,
     trigger_station_dispatch,
+    trigger_channel_dispatch,
+    reset_channel_dispatch,
     bulk_import_oscar_stations
 )
 from .viewsets import (
@@ -83,6 +85,16 @@ def urlconf_adl():
             'station-link/<int:station_link_id>/trigger-dispatch/<int:channel_id>/',
             trigger_station_dispatch,
             name='trigger_station_dispatch'
+        ),
+        path(
+            'dispatch-channel/<int:channel_id>/dispatch-now/',
+            trigger_channel_dispatch,
+            name='dispatch_channel_dispatch_now'
+        ),
+        path(
+            'dispatch-channel/<int:channel_id>/reset/',
+            reset_channel_dispatch,
+            name='dispatch_channel_reset'
         ),
     ]
 


### PR DESCRIPTION
Closes #111. Part of #103.

Gives operators without server access the two recovery levers, per channel, in the Wagtail admin:

- **Dispatch now** — enqueues `perform_channel_dispatch` immediately instead of waiting for the next beat tick
- **Reset** — deletes the channel's per-(channel, station) dispatch lock keys (all station links on its connections, including currently-excluded ones, which can hold stale locks) and triggers a fresh dispatch. Strictly one channel; deliberately no global reset.

Details:
- POST-only views mirroring the existing `trigger_station_dispatch` pattern; Wagtail admin auth covers the URLs (verified by test)
- `dispatch_station_lock_key()` extracted as the single source of the lock key format shared with `dispatch_station` (#109)
- Buttons live on the channel's station-links admin page, Reset behind a JS confirm

Tests via the admin test client with the task mocked: enqueue args, reset clears only the target channel's locks, anonymous redirected to login with no side effects, GET is a no-op, and a page-render smoke test covering the template/url wiring. Full suite 38 tests green via `make dev-test`.