### PR TITLE
Dispatch: test_connection() contract, wis2box MinIO probe, and admin Test connection button

### DIFF
--- a/adl/src/adl/core/dispatchers/wis2box.py
+++ b/adl/src/adl/core/dispatchers/wis2box.py
@@ -1,5 +1,6 @@
 import csv
 import logging
+import time
 from datetime import timedelta
 from io import StringIO, BytesIO
 
@@ -13,6 +14,12 @@ from adl.core.utils import get_object_or_none
 logger = logging.getLogger(__name__)
 
 WIS2BOX_STORAGE_REQUEST_TIMEOUT = 60
+
+# Interactive connection tests must stay snappy: separate, much shorter
+# timeout than the upload pool
+WIS2BOX_TEST_CONNECTION_TIMEOUT = 10
+
+WIS2BOX_INCOMING_BUCKET = "wis2box-incoming"
 
 MINIO_PATH = "incoming/"
 
@@ -69,6 +76,53 @@ WIS2BOX_CSV_HEADER = [
 
 def get_minio_client(endpoint, access_key, secret_key, secure=False):
     return Minio(endpoint, access_key=access_key, secret_key=secret_key, http_client=http_client, secure=secure)
+
+
+def test_wis2box_connection(channel):
+    """
+    Probe the channel's MinIO storage: reachability, authentication, and
+    presence of the wis2box incoming bucket. Never raises; always returns
+    within the test-connection timeout.
+    """
+    start = time.monotonic()
+
+    def latency_ms():
+        return int((time.monotonic() - start) * 1000)
+
+    try:
+        http = PoolManager(timeout=WIS2BOX_TEST_CONNECTION_TIMEOUT, retries=False)
+        client = Minio(
+            channel.storage_endpoint,
+            access_key=channel.storage_username,
+            secret_key=channel.storage_password,
+            http_client=http,
+            secure=channel.secure,
+        )
+        bucket_found = client.bucket_exists(WIS2BOX_INCOMING_BUCKET)
+    except Exception as e:
+        return {
+            "ok": False,
+            "supported": True,
+            "message": f"Connection failed: {e}",
+            "latency_ms": latency_ms(),
+        }
+
+    if not bucket_found:
+        return {
+            "ok": False,
+            "supported": True,
+            "message": f"Connected to {channel.storage_endpoint}, "
+                       f"but bucket '{WIS2BOX_INCOMING_BUCKET}' was not found",
+            "latency_ms": latency_ms(),
+        }
+
+    return {
+        "ok": True,
+        "supported": True,
+        "message": f"Connected to {channel.storage_endpoint}; "
+                   f"bucket '{WIS2BOX_INCOMING_BUCKET}' is accessible",
+        "latency_ms": latency_ms(),
+    }
 
 
 def get_wis2box_csv_station_metadata(station):

--- a/adl/src/adl/core/models.py
+++ b/adl/src/adl/core/models.py
@@ -28,7 +28,7 @@ from wagtailiconchooser.widgets import IconChooserWidget
 from adl.core.registries import plugin_registry
 from .blocks import QCChecksStreamBlock
 from .dispatchers import get_dispatch_channel_data
-from .dispatchers.wis2box import upload_to_wis2box
+from .dispatchers.wis2box import upload_to_wis2box, test_wis2box_connection
 from .units import units, validate_unit, TEMPERATURE_UNITS
 from .utils import (
     validate_as_integer,
@@ -991,6 +991,24 @@ class DispatchChannel(PolymorphicModel, ClusterableModel):
     
     def send_station_data(self, station_link, station_data_records):
         raise NotImplementedError("Method send_station_data must be implemented in the subclass")
+
+    def test_connection(self):
+        """
+        Probe whether the channel's destination is reachable and responsive.
+
+        Subclasses override this with a short, bounded check against their
+        destination (reachability + authentication). Implementations must
+        never raise and must never block for more than ~10 seconds.
+
+        :return: dict with keys ``ok`` (bool), ``supported`` (bool),
+            ``message`` (str) and ``latency_ms`` (int or None).
+        """
+        return {
+            "ok": False,
+            "supported": False,
+            "message": _("Connection test not supported for this channel type"),
+            "latency_ms": None,
+        }
     
     def get_data_records_by_station(self):
         data_records_by_station = get_dispatch_channel_data(self)
@@ -1138,6 +1156,9 @@ class Wis2BoxUpload(DispatchChannel):
     
     def send_station_data(self, station_link, data_records):
         return upload_to_wis2box(self, data_records)
+
+    def test_connection(self):
+        return test_wis2box_connection(self)
     
     def connection_details(self):
         return {

--- a/adl/src/adl/core/templates/core/dispatch_channel_station_links.html
+++ b/adl/src/adl/core/templates/core/dispatch_channel_station_links.html
@@ -19,6 +19,10 @@
                 {% csrf_token %}
                 <button type="submit" class="button">{% trans "Dispatch now" %}</button>
             </form>
+            <form method="post" action="{% url 'dispatch_channel_test_connection' channel.id %}">
+                {% csrf_token %}
+                <button type="submit" class="button button-secondary">{% trans "Test connection" %}</button>
+            </form>
             <form method="post" action="{% url 'dispatch_channel_reset' channel.id %}"
                   onsubmit="return confirm('{% trans 'Clear stale station dispatch locks for this channel and trigger a fresh dispatch?' %}')">
                 {% csrf_token %}

--- a/adl/src/adl/core/tests/test_dispatch_admin_actions.py
+++ b/adl/src/adl/core/tests/test_dispatch_admin_actions.py
@@ -96,5 +96,6 @@ class ChannelPageButtonsTests(DispatchAdminActionTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Dispatch now")
         self.assertContains(response, "Reset dispatch")
+        self.assertContains(response, "Test connection")
         self.assertContains(response, reverse("dispatch_channel_dispatch_now", args=[self.channel.id]))
         self.assertContains(response, reverse("dispatch_channel_reset", args=[self.channel.id]))

--- a/adl/src/adl/core/tests/test_dispatch_test_connection.py
+++ b/adl/src/adl/core/tests/test_dispatch_test_connection.py
@@ -1,0 +1,81 @@
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from adl.core.models import DispatchChannel, Wis2BoxUpload
+from .factories import Wis2BoxUploadFactory
+
+
+class BaseTestConnectionContractTests(TestCase):
+    def test_base_channel_reports_not_supported_without_raising(self):
+        channel = DispatchChannel.objects.create(name="Bare Channel")
+
+        result = channel.test_connection()
+
+        self.assertFalse(result["supported"])
+        self.assertFalse(result["ok"])
+        self.assertIn("not supported", result["message"])
+
+
+class Wis2BoxTestConnectionTests(TestCase):
+    def setUp(self):
+        self.channel = Wis2BoxUploadFactory()
+
+    def test_reachable_with_bucket_reports_ok_and_latency(self):
+        with patch("adl.core.dispatchers.wis2box.Minio") as mock_minio:
+            mock_minio.return_value.bucket_exists.return_value = True
+            result = self.channel.test_connection()
+
+        self.assertTrue(result["ok"])
+        self.assertTrue(result["supported"])
+        self.assertGreaterEqual(result["latency_ms"], 0)
+        mock_minio.return_value.bucket_exists.assert_called_once_with("wis2box-incoming")
+
+    def test_missing_bucket_reports_not_ok(self):
+        with patch("adl.core.dispatchers.wis2box.Minio") as mock_minio:
+            mock_minio.return_value.bucket_exists.return_value = False
+            result = self.channel.test_connection()
+
+        self.assertFalse(result["ok"])
+        self.assertTrue(result["supported"])
+        self.assertIn("wis2box-incoming", result["message"])
+
+    def test_connection_error_reports_not_ok_without_raising(self):
+        with patch("adl.core.dispatchers.wis2box.Minio") as mock_minio:
+            mock_minio.return_value.bucket_exists.side_effect = Exception("connection refused")
+            result = self.channel.test_connection()
+
+        self.assertFalse(result["ok"])
+        self.assertTrue(result["supported"])
+        self.assertIn("connection refused", result["message"])
+
+
+class TestConnectionAdminViewTests(TestCase):
+    def setUp(self):
+        self.channel = Wis2BoxUploadFactory()
+        self.user = get_user_model().objects.create_superuser(
+            username="admin", email="admin@example.com", password="test-pass"
+        )
+        self.client.force_login(self.user)
+        self.url = reverse("dispatch_channel_test_connection", args=[self.channel.id])
+
+    def test_post_runs_probe_and_redirects_with_result(self):
+        probe_result = {"ok": True, "supported": True, "message": "reachable", "latency_ms": 12}
+        with patch.object(Wis2BoxUpload, "test_connection", return_value=probe_result) as mock_probe:
+            response = self.client.post(
+                self.url, HTTP_REFERER="/admin/dispatch-channels/", follow=True
+            )
+
+        mock_probe.assert_called_once_with()
+        rendered_messages = [str(m) for m in response.context["messages"]]
+        self.assertTrue(any("reachable" in m for m in rendered_messages))
+
+    def test_anonymous_cannot_probe(self):
+        self.client.logout()
+        with patch.object(Wis2BoxUpload, "test_connection") as mock_probe:
+            response = self.client.post(self.url)
+
+        mock_probe.assert_not_called()
+        self.assertIn("login", response["Location"])

--- a/adl/src/adl/core/views.py
+++ b/adl/src/adl/core/views.py
@@ -1233,6 +1233,42 @@ def reset_channel_dispatch(request, channel_id):
     return redirect('wagtailadmin_home')
 
 
+def test_dispatch_channel_connection(request, channel_id):
+    """Synchronously probe a dispatch channel's destination.
+
+    Runs in the web process on purpose: a wedged dispatch queue must not be
+    able to mask a destination health check.
+    """
+    if request.method == 'POST':
+        dispatch_channel = get_object_or_404(DispatchChannel, id=channel_id)
+
+        result = dispatch_channel.test_connection()
+
+        if not result["supported"]:
+            messages.warning(request, result["message"])
+        elif result["ok"]:
+            messages.success(
+                request,
+                _('%(channel)s: %(message)s (%(latency)s ms)') % {
+                    'channel': dispatch_channel.name,
+                    'message': result["message"],
+                    'latency': result["latency_ms"],
+                }
+            )
+        else:
+            messages.error(
+                request,
+                _('%(channel)s: %(message)s') % {
+                    'channel': dispatch_channel.name,
+                    'message': result["message"],
+                }
+            )
+
+        return redirect(request.META.get('HTTP_REFERER', 'wagtailadmin_home'))
+
+    return redirect('wagtailadmin_home')
+
+
 def trigger_station_dispatch(request, station_link_id, channel_id):
     """Manually trigger data dispatch for a station link to a specific channel"""
     if request.method == 'POST':

--- a/adl/src/adl/core/wagtail_hooks.py
+++ b/adl/src/adl/core/wagtail_hooks.py
@@ -43,6 +43,7 @@ from .views import (
     trigger_station_dispatch,
     trigger_channel_dispatch,
     reset_channel_dispatch,
+    test_dispatch_channel_connection,
     bulk_import_oscar_stations
 )
 from .viewsets import (
@@ -95,6 +96,11 @@ def urlconf_adl():
             'dispatch-channel/<int:channel_id>/reset/',
             reset_channel_dispatch,
             name='dispatch_channel_reset'
+        ),
+        path(
+            'dispatch-channel/<int:channel_id>/test-connection/',
+            test_dispatch_channel_connection,
+            name='dispatch_channel_test_connection'
         ),
     ]
 


### PR DESCRIPTION
Closes #107. Part of #103.

Gives operators an immediate answer to 'is this destination alive?' and plugin authors a common contract to implement.

- `DispatchChannel.test_connection()` on the polymorphic base returns `{ok, supported, message, latency_ms}`; the base default reports 'not supported' without raising, so existing third-party dispatch channels keep working and the admin distinguishes unsupported from failed
- `Wis2BoxUpload` implements it as a MinIO `bucket_exists('wis2box-incoming')` probe using a dedicated 10s timeout pool (separate from the 60s upload pool), with three outcomes: reachable + bucket present, reachable but bucket missing, connection/auth failure — never raising
- POST-only admin view runs the probe **synchronously in the web process** — deliberately not via Celery, so a wedged dispatch queue can't mask its own health check — and reports ok/latency or the failure via the messages framework; button sits next to Dispatch now / Reset on the channel page

Tests: base contract, all three probe outcomes with the MinIO client mocked, admin view result surfacing, anonymous denied, button render smoke. Full suite 44 tests green via `make dev-test`.