### PR TITLE
Dispatch: dedicated 'dispatch' queue and worker container with PeriodicTask queue migration

### DIFF
--- a/adl/src/adl/config/settings/base.py
+++ b/adl/src/adl/config/settings/base.py
@@ -304,9 +304,9 @@ CELERY_RESULT_EXTENDED = True
 CELERY_TASK_ROUTES = {
     'adl.core.tasks.run_network_plugin': {'queue': 'adl'},
     'adl.core.tasks.process_station_link_batch': {'queue': 'adl'},
-    'adl.core.tasks.perform_channel_dispatch': {'queue': 'adl'},
-    'adl.core.tasks.dispatch_station': {'queue': 'adl'},
-    'adl.core.tasks.sweep_stale_dispatch_logs': {'queue': 'adl'},
+    'adl.core.tasks.perform_channel_dispatch': {'queue': 'dispatch'},
+    'adl.core.tasks.dispatch_station': {'queue': 'dispatch'},
+    'adl.core.tasks.sweep_stale_dispatch_logs': {'queue': 'dispatch'},
 }
 
 CACHES = {

--- a/adl/src/adl/core/migrations/0046_move_dispatch_periodic_tasks_to_dispatch_queue.py
+++ b/adl/src/adl/core/migrations/0046_move_dispatch_periodic_tasks_to_dispatch_queue.py
@@ -1,0 +1,26 @@
+from django.db import migrations
+
+OLD_QUEUE = "adl"
+NEW_QUEUE = "dispatch"
+DISPATCH_TASK_NAME = "adl.core.tasks.perform_channel_dispatch"
+
+
+def move_to_dispatch_queue(apps, schema_editor):
+    PeriodicTask = apps.get_model("django_celery_beat", "PeriodicTask")
+    PeriodicTask.objects.filter(task=DISPATCH_TASK_NAME, queue=OLD_QUEUE).update(queue=NEW_QUEUE)
+
+
+def move_back_to_adl_queue(apps, schema_editor):
+    PeriodicTask = apps.get_model("django_celery_beat", "PeriodicTask")
+    PeriodicTask.objects.filter(task=DISPATCH_TASK_NAME, queue=NEW_QUEUE).update(queue=OLD_QUEUE)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0045_dispatchchannelheartbeat"),
+        ("django_celery_beat", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.RunPython(move_to_dispatch_queue, move_back_to_adl_queue),
+    ]

--- a/adl/src/adl/core/tasks.py
+++ b/adl/src/adl/core/tasks.py
@@ -22,6 +22,10 @@ from .utils import get_object_or_none
 
 logger = logging.getLogger(__name__)
 
+# Dispatch tasks run on their own queue/worker so they can be restarted or
+# starved independently of ingestion
+DISPATCH_QUEUE_NAME = "dispatch"
+
 # Extra time allowed beyond the soft limit before the worker hard-kills a
 # station dispatch task
 DISPATCH_TIME_LIMIT_GRACE_SECONDS = 30
@@ -291,7 +295,7 @@ def perform_channel_dispatch(self, channel_id, station_link_ids=None):
     for station_link_id in ids:
         dispatch_station.apply_async(
             args=[channel_id, station_link_id],
-            queue="adl",
+            queue=DISPATCH_QUEUE_NAME,
             soft_time_limit=soft_time_limit,
             time_limit=soft_time_limit + DISPATCH_TIME_LIMIT_GRACE_SECONDS,
         )
@@ -466,7 +470,7 @@ def create_or_update_dispatch_channel_periodic_tasks(dispatch_channel):
             'task': sig.name,
             'args': json.dumps([dispatch_channel.id]),
             'enabled': enabled,
-            'queue': 'adl',
+            'queue': DISPATCH_QUEUE_NAME,
         }
     )
 

--- a/adl/src/adl/core/tests/test_dispatch_queue.py
+++ b/adl/src/adl/core/tests/test_dispatch_queue.py
@@ -1,0 +1,53 @@
+from unittest.mock import patch
+
+from django.conf import settings
+from django.test import TestCase
+from django_celery_beat.models import PeriodicTask
+
+from adl.core.tasks import (
+    create_or_update_dispatch_channel_periodic_tasks,
+    perform_channel_dispatch,
+)
+from .factories import StationLinkFactory, Wis2BoxUploadFactory
+
+
+class DispatchQueueRoutingTests(TestCase):
+    def test_dispatch_tasks_route_to_dispatch_queue(self):
+        routes = settings.CELERY_TASK_ROUTES
+        for task_name in (
+                "adl.core.tasks.perform_channel_dispatch",
+                "adl.core.tasks.dispatch_station",
+                "adl.core.tasks.sweep_stale_dispatch_logs",
+        ):
+            self.assertEqual(routes[task_name]["queue"], "dispatch", task_name)
+
+    def test_coordinator_enqueues_station_tasks_on_dispatch_queue(self):
+        link = StationLinkFactory()
+        channel = Wis2BoxUploadFactory()
+        channel.network_connections.add(link.network_connection)
+
+        with patch("adl.core.tasks.dispatch_station.apply_async") as mock_apply:
+            perform_channel_dispatch(channel.id)
+
+        self.assertEqual(mock_apply.call_args.kwargs["queue"], "dispatch")
+
+
+class DispatchPeriodicTaskQueueTests(TestCase):
+    def test_periodic_task_created_on_dispatch_queue(self):
+        channel = Wis2BoxUploadFactory()
+
+        create_or_update_dispatch_channel_periodic_tasks(channel)
+
+        task = PeriodicTask.objects.get(args=f"[{channel.id}]")
+        self.assertEqual(task.queue, "dispatch")
+
+    def test_existing_periodic_task_migrates_from_old_queue_on_update(self):
+        channel = Wis2BoxUploadFactory()
+        create_or_update_dispatch_channel_periodic_tasks(channel)
+        # simulate a pre-upgrade row stranded on the old queue
+        PeriodicTask.objects.filter(args=f"[{channel.id}]").update(queue="adl")
+
+        create_or_update_dispatch_channel_periodic_tasks(channel)
+
+        task = PeriodicTask.objects.get(args=f"[{channel.id}]")
+        self.assertEqual(task.queue, "dispatch")

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -30,6 +30,15 @@ services:
     volumes:
       - ./adl:/adl/app
 
+  adl_celery_worker_dispatch:
+    build:
+      target: dev
+    command: celery-worker-dispatch
+    environment:
+      DEBUG: "True"
+    volumes:
+      - ./adl:/adl/app
+
   adl_celery_beat:
     build:
       target: dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -144,6 +144,34 @@ services:
       - ${ADL_MEDIA_VOLUME:-./docker/media}:/adl/app/src/adl/media
       - ${ADL_BACKUP_VOLUME:-./docker/backup}:/adl/app/src/adl/backup
 
+  adl_celery_worker_dispatch:
+    container_name: adl_celery_worker_dispatch
+    image: adl
+    build:
+      context: .
+      dockerfile: ${ADL_DOCKERFILE:-Dockerfile}
+      target: prod
+      args:
+        - UID=${UID}
+        - GID=${GID}
+        - DOCKER_COMPOSE_WAIT_PLATFORM_SUFFIX=${DOCKER_COMPOSE_WAIT_PLATFORM_SUFFIX:-}
+        - ADL_PLUGIN_GIT_REPOS=${ADL_PLUGIN_GIT_REPOS}
+    restart: unless-stopped
+    init: true
+    command: celery-worker-dispatch
+    environment:
+      <<: *backend-variables
+      WAIT_HOSTS: adl_db:5432,adl_redis:6379,adl:8000
+      ADL_DISABLE_PLUGIN_INSTALL_ON_STARTUP: "true"
+      ADL_CELERY_WORKER_CONCURRENCY: ${ADL_CELERY_WORKER_DISPATCH_CONCURRENCY:-2}
+    depends_on:
+      - adl_db
+      - adl_redis
+    volumes:
+      - ${ADL_STATIC_VOLUME:-./docker/static}:/adl/app/src/adl/static
+      - ${ADL_MEDIA_VOLUME:-./docker/media}:/adl/app/src/adl/media
+      - ${ADL_BACKUP_VOLUME:-./docker/backup}:/adl/app/src/adl/backup
+
   adl_celery_beat:
     container_name: adl_celery_beat
     image: adl

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -31,7 +31,8 @@ gunicorn-wsgi       : Start ADL using a prod ready gunicorn server:
                          * Automatically migrates the database on startup.
                          * Binds to 0.0.0.0
 celery-worker-default: Start the Celery worker (default queue)
-celery-worker-adl   : Start the Celery worker for the ADL ingestion/dispatch queue
+celery-worker-adl   : Start the Celery worker for the ADL ingestion queue
+celery-worker-dispatch : Start the Celery worker for the outbound dispatch queue
 celery-worker-dev   : Start the Celery worker with auto-reload on code changes
                       (requires the dev build target)
 celery-beat         : Start the Celery beat scheduler
@@ -144,6 +145,9 @@ celery-worker-default)
     ;;
 celery-worker-adl)
     start_celery_worker -Q adl -n adl-worker@%h "${@:2}"
+    ;;
+celery-worker-dispatch)
+    start_celery_worker -Q dispatch -n dispatch-worker@%h "${@:2}"
     ;;
 celery-worker-dev)
     startup_plugin_setup


### PR DESCRIPTION
Closes #106. Part of #103.

Isolates dispatch from ingestion at the worker level: a stuck or misbehaving dispatch worker can now be restarted without interrupting in-flight ingestion, and a pathological ingestion plugin can't starve dispatch.

- `perform_channel_dispatch`, `dispatch_station`, and `sweep_stale_dispatch_logs` route to a new `dispatch` queue — via `CELERY_TASK_ROUTES` and every explicit enqueue site (`DISPATCH_QUEUE_NAME` constant)
- Upgrade path: `create_or_update_dispatch_channel_periodic_tasks` writes the new queue going forward, and data migration `0046` moves existing `django_celery_beat` PeriodicTask rows stranded on `adl`, so upgraded deployments don't silently stop dispatching
- New `celery-worker-dispatch` entrypoint subcommand and `adl_celery_worker_dispatch` compose service (prod + dev), default concurrency 2 via `ADL_CELERY_WORKER_DISPATCH_CONCURRENCY`

Verified live: the rebuilt worker binds only `[queues] dispatch` with the dispatch tasks registered, and the migration applied cleanly to an existing DB.

Tests: route config, coordinator enqueue queue, periodic-task creation on the new queue and upgrade-from-old-queue semantics. Full suite 59 tests green via `make dev-test`.