### PR TITLE
Dispatch: 'Show active locks' page — informed Reset with RUNNING/STALE/UNKNOWN lock status

### DIFF
--- a/adl/src/adl/core/tasks.py
+++ b/adl/src/adl/core/tasks.py
@@ -39,6 +39,36 @@ def dispatch_station_lock_key(channel_id, station_link_id):
     return f"lock:dispatch:{channel_id}:{station_link_id}"
 
 
+def get_active_dispatch_tasks(timeout=2.0):
+    """
+    Map of currently executing station dispatches, keyed by
+    ``(channel_id, station_link_id)`` with the task's start timestamp as value.
+
+    Returns ``None`` (rather than ``{}``) when no worker replied to the
+    inspect broadcast — callers must treat that as "unknown", not "idle":
+    the dispatch worker may be down, restarting, or too slow to answer
+    within ``timeout``. Never raises.
+    """
+    try:
+        active = app.control.inspect(timeout=timeout).active()
+    except Exception as e:
+        logger.warning("[DISPATCH] Could not inspect active dispatch tasks: %s", e)
+        return None
+
+    if not active:
+        return None
+
+    running = {}
+    for worker_tasks in active.values():
+        for task in worker_tasks:
+            if task.get("name") != "adl.core.tasks.dispatch_station":
+                continue
+            args = task.get("args") or []
+            if len(args) >= 2:
+                running[(args[0], args[1])] = task.get("time_start")
+    return running
+
+
 @app.task(base=Singleton, bind=True)
 def run_backup(self):
     # TODO: defer until we find a fix with timescale db backup

--- a/adl/src/adl/core/templates/core/dispatch_channel_locks.html
+++ b/adl/src/adl/core/templates/core/dispatch_channel_locks.html
@@ -1,0 +1,92 @@
+{% extends "wagtailadmin/generic/base.html" %}
+{% load i18n wagtailadmin_tags static %}
+
+{% block main_content %}
+    <div style="margin-top: 40px">
+        <h1 class="w-text-h2">{% trans "Dispatch Locks" %} — {{ channel.name }}</h1>
+
+        <div class="help-block help-info">
+            <svg class="icon icon-help icon" aria-hidden="true">
+                <use href="#icon-help"></use>
+            </svg>
+            <p style="color:#666;">
+                {% trans "Each running station dispatch holds a lock. RUNNING = a dispatch task is actively executing. STALE = the lock is held but no task is behind it (a worker died); it will expire on its own when the TTL runs out, or you can clear it below." %}
+            </p>
+        </div>
+
+        {% if not worker_responsive %}
+            <div class="help-block help-warning">
+                <svg class="icon icon-warning icon" aria-hidden="true">
+                    <use href="#icon-warning"></use>
+                </svg>
+                <p>
+                    {% trans "The dispatch worker did not respond — it may be down, restarting, or overloaded. Lock statuses are UNKNOWN and cannot be safely cleared as stale. Consider restarting the dispatch worker." %}
+                </p>
+            </div>
+        {% endif %}
+
+        {% if lock_rows %}
+            <table class="listing">
+                <thead>
+                <tr>
+                    <th>{% trans "Station" %}</th>
+                    <th>{% trans "Status" %}</th>
+                    <th>{% trans "Running for" %}</th>
+                    <th>{% trans "Lock expires in" %}</th>
+                </tr>
+                </thead>
+                <tbody>
+                {% for row in lock_rows %}
+                    <tr>
+                        <td>{{ row.station_link.station.name }}</td>
+                        <td>
+                            {% if row.status == "RUNNING" %}
+                                <span style="background:#1f7d51; color:#fff; padding:2px 8px; border-radius:3px; font-weight:bold;">RUNNING</span>
+                            {% elif row.status == "STALE" %}
+                                <span style="background:#d9303e; color:#fff; padding:2px 8px; border-radius:3px; font-weight:bold;">STALE</span>
+                            {% else %}
+                                <span style="background:#666; color:#fff; padding:2px 8px; border-radius:3px; font-weight:bold;">UNKNOWN</span>
+                            {% endif %}
+                        </td>
+                        <td>
+                            {% if row.running_seconds is not None %}
+                                {{ row.running_seconds }} {% trans "seconds" %}
+                            {% else %}
+                                —
+                            {% endif %}
+                        </td>
+                        <td>
+                            {% if row.ttl_seconds %}
+                                {{ row.ttl_seconds }} {% trans "seconds" %}
+                            {% else %}
+                                —
+                            {% endif %}
+                        </td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        {% else %}
+            <p style="margin:20px 0; color:#666;">
+                {% trans "No dispatch locks currently held for this channel." %}
+            </p>
+        {% endif %}
+
+        <div style="display:flex; gap:10px; margin:20px 0;">
+            <form method="post" action="{% url 'dispatch_channel_reset' channel.id %}">
+                {% csrf_token %}
+                <input type="hidden" name="scope" value="stale">
+                <button type="submit" class="button"
+                        {% if not worker_responsive or stale_count == 0 %}disabled{% endif %}>
+                    {% blocktrans count counter=stale_count %}Clear {{ counter }} stale lock &amp; dispatch{% plural %}Clear {{ counter }} stale locks &amp; dispatch{% endblocktrans %}
+                </button>
+            </form>
+            <form method="post" action="{% url 'dispatch_channel_reset' channel.id %}"
+                  onsubmit="return confirm('{% trans 'Clear ALL locks, including RUNNING ones? A running dispatch keeps executing and a duplicate may start for the same station, which can send the same records twice.' %}')">
+                {% csrf_token %}
+                <input type="hidden" name="scope" value="all">
+                <button type="submit" class="button no">{% trans "Clear ALL locks & dispatch" %}</button>
+            </form>
+        </div>
+    </div>
+{% endblock %}

--- a/adl/src/adl/core/templates/core/dispatch_channel_station_links.html
+++ b/adl/src/adl/core/templates/core/dispatch_channel_station_links.html
@@ -38,11 +38,9 @@
                 {% csrf_token %}
                 <button type="submit" class="button button-secondary">{% trans "Test connection" %}</button>
             </form>
-            <form method="post" action="{% url 'dispatch_channel_reset' channel.id %}"
-                  onsubmit="return confirm('{% trans 'Clear stale station dispatch locks for this channel and trigger a fresh dispatch?' %}')">
-                {% csrf_token %}
-                <button type="submit" class="button no">{% trans "Reset dispatch" %}</button>
-            </form>
+            <a href="{% url 'dispatch_channel_locks' channel.id %}" class="button button-secondary">
+                {% trans "Show active locks" %}
+            </a>
         </div>
 
         <form method="post" action="?page={{ page_obj.number }}">

--- a/adl/src/adl/core/tests/test_dispatch_admin_actions.py
+++ b/adl/src/adl/core/tests/test_dispatch_admin_actions.py
@@ -95,7 +95,9 @@ class ChannelPageButtonsTests(DispatchAdminActionTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Dispatch now")
-        self.assertContains(response, "Reset dispatch")
+        self.assertContains(response, "Show active locks")
         self.assertContains(response, "Test connection")
         self.assertContains(response, reverse("dispatch_channel_dispatch_now", args=[self.channel.id]))
-        self.assertContains(response, reverse("dispatch_channel_reset", args=[self.channel.id]))
+        self.assertContains(response, reverse("dispatch_channel_locks", args=[self.channel.id]))
+        # Reset is no longer directly on this page — it lives on the locks page
+        self.assertNotContains(response, reverse("dispatch_channel_reset", args=[self.channel.id]))

--- a/adl/src/adl/core/tests/test_dispatch_locks.py
+++ b/adl/src/adl/core/tests/test_dispatch_locks.py
@@ -1,0 +1,162 @@
+import time
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from django.test import SimpleTestCase, TestCase
+from django.urls import reverse
+
+from adl.core.tasks import dispatch_station_lock_key, get_active_dispatch_tasks
+from .factories import StationLinkFactory, Wis2BoxUploadFactory
+
+
+class GetActiveDispatchTasksTests(SimpleTestCase):
+    def _run_with_active(self, active_reply):
+        with patch("adl.core.tasks.app.control.inspect") as mock_inspect:
+            mock_inspect.return_value.active.return_value = active_reply
+            return get_active_dispatch_tasks()
+
+    def test_maps_running_dispatch_tasks_by_channel_and_station(self):
+        reply = {
+            "dispatch-worker@host": [
+                {
+                    "name": "adl.core.tasks.dispatch_station",
+                    "args": [7, 42],
+                    "time_start": 1750000000.0,
+                },
+                {  # non-dispatch task on the same worker is ignored
+                    "name": "adl.core.tasks.process_station_link_batch",
+                    "args": [1, [2, 3]],
+                    "time_start": 1750000001.0,
+                },
+            ]
+        }
+
+        result = self._run_with_active(reply)
+
+        self.assertEqual(result, {(7, 42): 1750000000.0})
+
+    def test_returns_none_when_no_worker_replies(self):
+        self.assertIsNone(self._run_with_active(None))
+        self.assertIsNone(self._run_with_active({}))
+
+    def test_returns_none_instead_of_raising_on_broker_error(self):
+        with patch("adl.core.tasks.app.control.inspect", side_effect=Exception("broker down")):
+            self.assertIsNone(get_active_dispatch_tasks())
+
+
+class LocksPageTestCase(TestCase):
+    def setUp(self):
+        self.link = StationLinkFactory()
+        self.channel = Wis2BoxUploadFactory()
+        self.channel.network_connections.add(self.link.network_connection)
+        user = get_user_model().objects.create_superuser(
+            username="admin", email="admin@example.com", password="test-pass"
+        )
+        self.client.force_login(user)
+        self.url = reverse("dispatch_channel_locks", args=[self.channel.id])
+
+    def hold_lock(self, station_link, ttl=300):
+        key = dispatch_station_lock_key(self.channel.id, station_link.id)
+        cache.set(key, "locked", timeout=ttl)
+        self.addCleanup(cache.delete, key)
+        return key
+
+    def get_page(self, active_tasks):
+        with patch("adl.core.views.get_active_dispatch_tasks", return_value=active_tasks):
+            return self.client.get(self.url)
+
+
+class LocksPageRowStatusTests(LocksPageTestCase):
+    RUNNING_BADGE = ">RUNNING</span>"
+    STALE_BADGE = ">STALE</span>"
+
+    def test_lock_with_matching_active_task_shows_running(self):
+        self.hold_lock(self.link)
+        active = {(self.channel.id, self.link.id): time.time() - 65}
+
+        response = self.get_page(active)
+
+        self.assertContains(response, self.link.station.name)
+        self.assertContains(response, self.RUNNING_BADGE)
+        self.assertNotContains(response, self.STALE_BADGE)
+
+    def test_lock_without_active_task_shows_stale(self):
+        self.hold_lock(self.link)
+
+        response = self.get_page(active_tasks={})
+
+        self.assertContains(response, self.link.station.name)
+        self.assertContains(response, self.STALE_BADGE)
+        self.assertNotContains(response, self.RUNNING_BADGE)
+
+    def test_no_worker_reply_shows_unknown_banner_and_disables_stale_clear(self):
+        self.hold_lock(self.link)
+
+        response = self.get_page(active_tasks=None)
+
+        self.assertContains(response, ">UNKNOWN</span>")
+        self.assertContains(response, "did not respond")
+        # the safe clear button is disabled without worker evidence
+        self.assertRegex(
+            response.content.decode(),
+            r'name="scope" value="stale">\s*<button[^>]*disabled',
+        )
+
+    def test_no_locks_shows_empty_state(self):
+        response = self.get_page(active_tasks={})
+
+        self.assertContains(response, "No dispatch locks currently held")
+        self.assertNotContains(response, self.STALE_BADGE)
+
+    def test_anonymous_is_redirected_to_login(self):
+        self.client.logout()
+        response = self.client.get(self.url)
+        self.assertIn("login", response["Location"])
+
+
+class ResetScopeTests(LocksPageTestCase):
+    def setUp(self):
+        super().setUp()
+        self.other_link = StationLinkFactory(
+            network_connection=self.link.network_connection
+        )
+        self.reset_url = reverse("dispatch_channel_reset", args=[self.channel.id])
+
+    def post_reset(self, scope, active_tasks):
+        with patch("adl.core.views.get_active_dispatch_tasks", return_value=active_tasks), \
+                patch("adl.core.views.perform_channel_dispatch") as mock_task:
+            response = self.client.post(
+                self.reset_url, {"scope": scope}, HTTP_REFERER="/admin/", follow=True
+            )
+        return response, mock_task
+
+    def test_stale_scope_clears_only_stale_locks(self):
+        running_key = self.hold_lock(self.link)
+        stale_key = self.hold_lock(self.other_link)
+        active = {(self.channel.id, self.link.id): time.time() - 10}
+
+        response, mock_task = self.post_reset("stale", active_tasks=active)
+
+        self.assertIsNone(cache.get(stale_key))  # cleared
+        self.assertEqual(cache.get(running_key), "locked")  # kept
+        mock_task.delay.assert_called_once_with(self.channel.id)
+
+    def test_stale_scope_with_no_worker_reply_clears_nothing(self):
+        key = self.hold_lock(self.link)
+
+        response, mock_task = self.post_reset("stale", active_tasks=None)
+
+        self.assertEqual(cache.get(key), "locked")  # untouched
+        mock_task.delay.assert_not_called()
+        rendered_messages = [str(m) for m in response.context["messages"]]
+        self.assertTrue(any("did not respond" in m for m in rendered_messages))
+
+    def test_all_scope_clears_running_locks_too(self):
+        running_key = self.hold_lock(self.link)
+        active = {(self.channel.id, self.link.id): time.time() - 10}
+
+        response, mock_task = self.post_reset("all", active_tasks=active)
+
+        self.assertIsNone(cache.get(running_key))
+        mock_task.delay.assert_called_once_with(self.channel.id)

--- a/adl/src/adl/core/views.py
+++ b/adl/src/adl/core/views.py
@@ -54,7 +54,12 @@ from .registries import (
     plugin_registry
 )
 from .table import LinkColumnWithIcon
-from .tasks import process_station_link_batch, perform_channel_dispatch, dispatch_station_lock_key
+from .tasks import (
+    process_station_link_batch,
+    perform_channel_dispatch,
+    dispatch_station_lock_key,
+    get_active_dispatch_tasks,
+)
 from .utils import (
     get_stations_for_country_live,
     get_stations_for_country_local,
@@ -1196,10 +1201,90 @@ def trigger_channel_dispatch(request, channel_id):
     return redirect('wagtailadmin_home')
 
 
+def _channel_lock_rows(dispatch_channel):
+    """Held dispatch locks for a channel, correlated with running tasks.
+
+    Returns (rows, worker_responsive, stale_count). Row status is RUNNING
+    when a matching dispatch_station task is executing, STALE when the lock
+    is held with no task behind it, UNKNOWN when no worker answered inspect.
+    """
+    import time as time_mod
+
+    station_links = StationLink.objects.filter(
+        network_connection__in=dispatch_channel.network_connections.all()
+    ).select_related("station")
+
+    active_tasks = get_active_dispatch_tasks()
+    worker_responsive = active_tasks is not None
+
+    rows = []
+    stale_count = 0
+    for station_link in station_links:
+        lock_key = dispatch_station_lock_key(dispatch_channel.id, station_link.id)
+        if cache.get(lock_key) is None:
+            continue
+
+        ttl = cache.ttl(lock_key)
+        if not worker_responsive:
+            status = "UNKNOWN"
+            running_seconds = None
+        elif (dispatch_channel.id, station_link.id) in active_tasks:
+            status = "RUNNING"
+            time_start = active_tasks[(dispatch_channel.id, station_link.id)]
+            running_seconds = int(time_mod.time() - time_start) if time_start else None
+        else:
+            status = "STALE"
+            running_seconds = None
+            stale_count += 1
+
+        rows.append({
+            "station_link": station_link,
+            "lock_key": lock_key,
+            "status": status,
+            "ttl_seconds": ttl,
+            "running_seconds": running_seconds,
+        })
+
+    return rows, worker_responsive, stale_count
+
+
+def dispatch_channel_locks(request, channel_id):
+    """Show the channel's held per-station dispatch locks and their status."""
+    channel = get_object_or_404(DispatchChannel, pk=channel_id)
+
+    rows, worker_responsive, stale_count = _channel_lock_rows(channel)
+
+    breadcrumbs_items = [
+        {"url": reverse_lazy("wagtailadmin_home"), "label": _("Home")},
+        {"url": reverse_lazy("dispatch_channels_list"), "label": _("Dispatch Channels")},
+        {"url": reverse("dispatch_channel_station_links", args=[channel.id]), "label": channel.name},
+        {"url": "", "label": _("Active Locks")},
+    ]
+
+    context = {
+        "breadcrumbs_items": breadcrumbs_items,
+        "page_title": _("Dispatch Locks"),
+        "channel": channel,
+        "lock_rows": rows,
+        "worker_responsive": worker_responsive,
+        "stale_count": stale_count,
+    }
+    return render(request, "core/dispatch_channel_locks.html", context=context)
+
+
 def reset_channel_dispatch(request, channel_id):
-    """Clear the channel's per-station dispatch locks and trigger a fresh dispatch"""
+    """Clear the channel's per-station dispatch locks and trigger a fresh dispatch.
+
+    POST param ``scope``:
+    - ``all`` (default): clear every lock, including RUNNING ones.
+    - ``stale``: clear only locks with no dispatch task behind them, verified
+      against a fresh worker inspect at POST time. Refuses to clear anything
+      if the worker does not respond — without evidence nothing is provably
+      stale, and clearing a live lock invites duplicate sends.
+    """
     if request.method == 'POST':
         dispatch_channel = get_object_or_404(DispatchChannel, id=channel_id)
+        scope = request.POST.get('scope', 'all')
 
         try:
             # All station links on the channel's connections, including ones
@@ -1210,8 +1295,26 @@ def reset_channel_dispatch(request, channel_id):
                 ).values_list("id", flat=True)
             )
 
-            lock_keys = [dispatch_station_lock_key(dispatch_channel.id, sl_id)
-                         for sl_id in station_link_ids]
+            if scope == 'stale':
+                active_tasks = get_active_dispatch_tasks()
+                if active_tasks is None:
+                    messages.error(
+                        request,
+                        _('The dispatch worker did not respond, so no lock can be '
+                          'proven stale. Nothing was cleared. Use "Clear ALL locks" '
+                          'or restart the dispatch worker.')
+                    )
+                    return redirect(request.META.get('HTTP_REFERER', 'wagtailadmin_home'))
+
+                lock_keys = [
+                    dispatch_station_lock_key(dispatch_channel.id, sl_id)
+                    for sl_id in station_link_ids
+                    if (dispatch_channel.id, sl_id) not in active_tasks
+                ]
+            else:
+                lock_keys = [dispatch_station_lock_key(dispatch_channel.id, sl_id)
+                             for sl_id in station_link_ids]
+
             if lock_keys:
                 cache.delete_many(lock_keys)
 
@@ -1219,9 +1322,10 @@ def reset_channel_dispatch(request, channel_id):
 
             messages.success(
                 request,
-                _('Dispatch reset for %(channel)s: cleared station locks and '
+                _('Dispatch reset for %(channel)s: cleared %(scope)s station locks and '
                   'triggered a fresh dispatch.') % {
-                    'channel': dispatch_channel.name
+                    'channel': dispatch_channel.name,
+                    'scope': _('stale') if scope == 'stale' else _('all'),
                 }
             )
         except Exception as e:

--- a/adl/src/adl/core/wagtail_hooks.py
+++ b/adl/src/adl/core/wagtail_hooks.py
@@ -44,6 +44,7 @@ from .views import (
     trigger_channel_dispatch,
     reset_channel_dispatch,
     test_dispatch_channel_connection,
+    dispatch_channel_locks,
     bulk_import_oscar_stations
 )
 from .viewsets import (
@@ -101,6 +102,11 @@ def urlconf_adl():
             'dispatch-channel/<int:channel_id>/test-connection/',
             test_dispatch_channel_connection,
             name='dispatch_channel_test_connection'
+        ),
+        path(
+            'dispatch-channel/<int:channel_id>/locks/',
+            dispatch_channel_locks,
+            name='dispatch_channel_locks'
         ),
     ]
 

--- a/docs/user_guide/dispatch_troubleshooting.md
+++ b/docs/user_guide/dispatch_troubleshooting.md
@@ -76,16 +76,35 @@ immediately, including latency.
   missing bucket, or a network/firewall problem between ADL and the
   destination.
 
-## Step 3: Force a run — Dispatch now / Reset
+## Step 3: Force a run — Dispatch now / Show active locks
 
 - **Dispatch now** enqueues an immediate dispatch run for the channel,
   without waiting for the next scheduled tick. Watch the activity logs for
   the outcome.
-- **Reset dispatch** clears the channel's per-station locks first, then
-  triggers a fresh run. Use this if stations show repeated SKIPPED entries
-  that never clear on their own.
+- **Show active locks** opens a page listing every per-station dispatch lock
+  the channel currently holds, with its true status. Use it when stations
+  show repeated SKIPPED entries that never clear on their own. Each lock is
+  shown as:
+  - **RUNNING** — a dispatch task is actively executing for this station
+    (the elapsed time is shown). This is healthy; do not clear it.
+  - **STALE** — the lock is held but no task is behind it (a worker died
+    while dispatching). It will expire on its own when its TTL runs out,
+    or you can clear it immediately.
+  - **UNKNOWN** — the dispatch worker did not respond to the status query;
+    it may be down, restarting, or overloaded. This is itself a strong
+    signal — go to step 4.
 
-Both actions affect only the selected channel.
+  At the bottom of the page:
+  - **Clear stale locks & dispatch** removes only the provably-stale locks
+    and triggers a fresh run. This is the safe default. It is disabled when
+    the worker is unresponsive (nothing can be proven stale) or when there
+    is nothing stale to clear.
+  - **Clear ALL locks & dispatch** removes every lock, including RUNNING
+    ones. A running dispatch keeps executing, and a duplicate task may
+    start for the same station — which can send the same records twice.
+    Use only when you accept that risk.
+
+All actions affect only the selected channel.
 
 ## Step 4: Restart the dispatch worker
 

--- a/docs/user_guide/manage_dispatch_channels.md
+++ b/docs/user_guide/manage_dispatch_channels.md
@@ -273,7 +273,9 @@ with a red **OVERDUE** badge if it has not run on schedule, and provides three a
   scheduled check
 - **Test connection**: Synchronously probe the destination (reachability, credentials,
   and for WIS2BOX the incoming bucket) and show the result with latency
-- **Reset dispatch**: Clear the channel's per-station locks and trigger a fresh run
+- **Show active locks**: Open a page listing the channel's held per-station dispatch
+  locks with their status (RUNNING / STALE / UNKNOWN), from which stale locks — or,
+  with a warning, all locks — can be cleared and a fresh run triggered
 
 See [Dispatch Troubleshooting](dispatch_troubleshooting.md) for when and how to use
 each of these.


### PR DESCRIPTION
Follow-up to #103 (operator visibility gap raised post-epic).

Reset previously cleared all per-station locks blindly — deleting a RUNNING task's lock lets a duplicate `dispatch_station` start and can double-send records. Reset is now an informed action:

- **Show active locks** (replaces the Reset button on the station-links page) opens a page listing each held lock with its true status, correlated against `celery inspect active` called from code (`app.control.inspect()`): **RUNNING** (task executing, elapsed time shown), **STALE** (lock held, no task behind it), **UNKNOWN** (worker didn't answer within ~2s — warning banner, itself a diagnostic signal)
- Two actions at the bottom: **Clear stale locks & dispatch** (safe default; disabled when the worker is unresponsive or nothing is stale) and **Clear ALL locks & dispatch** (old semantics, behind a duplicate-send warning confirm)
- `scope=stale` recomputes staleness **server-side at POST time** with a fresh inspect — never trusting the rendered page — and refuses to clear anything without worker evidence
- New `get_active_dispatch_tasks()` helper distinguishes None (no worker reply → unknown) from {} (workers idle); verified against the live dispatch worker in the dev stack

Tests: helper contract (task mapping, no-reply, broker error), page statuses/banner/disabled-button/empty-state, both reset scopes incl. the refuse-on-no-reply path, anonymous denied. Full suite 70 tests green via `make dev-test`; docs updated (troubleshooting step 3, channel actions), Sphinx clean.