### PR TITLE
docs: record agent skill config and template conventions

### DIFF
--- a/.claude/docs/template_conventions.md
+++ b/.claude/docs/template_conventions.md
@@ -1,0 +1,136 @@
+# Template Conventions (Django/Wagtail HTML)
+
+Conventions for all HTML templates in ADL. Referenced from `CLAUDE.md`.
+
+## General rules
+
+- **No inline styles** — never use `style="..."` attributes. Extract all CSS into a
+  `{% block extra_css %}<style>…</style>{% endblock %}` block and give elements semantic class names.
+  When the same vocabulary is needed on more than one page (status badges, pills), escalate to a
+  shared stylesheet loaded by an `insert_global_admin_css` hook rather than copying the block.
+- **Modern JS** — use `const` and `let`; never `var`.
+- **JS placement** — all JavaScript goes in `{% block extra_js %}…{% endblock %}` at the bottom of the template. Wrap
+  code in `document.addEventListener('DOMContentLoaded', function () { … })` instead of IIFEs `(function(){ … }())`.
+
+## Admin pages: extend `wagtailadmin/generic/base.html`
+
+Every function-based-view admin page extends **`wagtailadmin/generic/base.html`** — never
+`wagtailadmin/base.html` with a manual header include. The generic base renders Wagtail's slim header
+(breadcrumbs + screen-reader-only `h1`) automatically when `breadcrumbs_items` is in the context.
+
+Do **not** include `wagtailadmin/shared/header.html` yourself: that template silently ignores a
+`breadcrumbs` variable (it has a fixed list of accepted variables), which is exactly the bug this
+pattern replaced.
+
+**One legitimate exception:** `config/templates/wagtailadmin/base.html` extends `wagtailadmin/base.html`
+because it *is* ADL's override of Wagtail's base — it overrides `{% block branding_logo %}` to inject the
+ADL logo and version. That file is infrastructure, not a page. No page template should follow it.
+
+### Template contract
+
+```django
+{% extends "wagtailadmin/generic/base.html" %}
+{% load i18n wagtailadmin_tags %}
+
+{% block titletag %}…{% endblock %}
+
+{% block extra_css %}
+    {{ block.super }}
+    <style>…</style>
+{% endblock %}
+
+{% block main_content %}
+    …page body…
+{% endblock %}
+```
+
+- Body goes in `{% block main_content %}` — the base already wraps it in `<div class="nice-padding">`,
+  so never add your own `nice-padding` wrapper.
+- **Top breathing space belongs in a global hook, not the page.** ADL does not yet have an
+  `insert_global_admin_css` hook, so existing pages hack it per-page — `dispatch_channel_locks.html`
+  opens with `<div style="margin-top: 40px">`. When the hook is added to `core/wagtail_hooks.py`, it
+  should apply `margin-top: 2rem` (the `w-mt-8` value Wagtail's own pages use) to the slim-header +
+  bare-`nice-padding` pairing, and those per-page hacks come out. Don't add new ones.
+
+### View context contract
+
+```python
+context = {
+    "breadcrumbs_items": [
+        {"url": reverse("wagtailadmin_home"), "label": _("Home")},
+        {"url": reverse("connections_list"), "label": _("Connections")},
+        {"url": None, "label": current_page_label},  # leaf: url=None, NOT ""
+    ],
+    "header_title": …,  # slim header's sr-only h1 + titletag fallback
+"header_icon": "cogs",  # icon shown beside the breadcrumbs
+...
+}
+```
+
+- **Leaf crumb uses `url: None`** — the breadcrumbs component checks `is not None`, so an empty
+  string renders a useless self-link.
+- `header_title` should carry what a big header would have shown: combine title and subtitle
+  sensibly, e.g. `_("Dispatch Locks — %s") % channel.name`.
+- Without `breadcrumbs_items` in context the base falls back to the old big header
+  (`page_title`/`page_subtitle`) — always provide a trail instead.
+
+### What the slim header cannot do
+
+- **No visible page title** — the page identity is carried by the leaf breadcrumb. If the old
+  header's subtitle carried real information, fold it into the leaf crumb label
+  (e.g. `"Step 2 of 3 — Feed Details"`) or add a lead line at the top of `main_content`.
+- **No action buttons** — `action_url`/`action_text` don't exist here. Put action bars
+  (e.g. "New config", "Edit Details") at the top of `main_content` using the
+  `button bicolor button--icon` idiom.
+
+Reference examples: `core/templates/core/dispatch_channel_locks.html` + its view
+`core/views.py:dispatch_channel_locks` (breadcrumbs built in the view, `<table class="listing">`,
+`help-block help-info` callouts, POST-form actions), and `core/templates/core/connection_list.html`.
+
+## CSS variables
+
+ADL has **one** CSS token context, and one place that deliberately isn't CSS at all:
+
+| Context                                                                  | Variables                          | Where defined        |
+|--------------------------------------------------------------------------|------------------------------------|----------------------|
+| **Wagtail admin** templates (`extends "wagtailadmin/generic/base.html"`) | `--w-color-*`                      | Wagtail 7 admin CSS  |
+| **Vue components** (`monitoring/monitoring-ui-vue/`, `viewer/`)          | PrimeVue theme + SFC-scoped styles | the component itself |
+
+Vue components are mounted into admin pages but style themselves through PrimeVue and scoped SFC
+styles. Don't reach for `--w-color-*` inside a `.vue` file, and don't invent a second token
+namespace for ADL — there is no project-branded token set, and adding one would need a real reason.
+
+**Wagtail 7 removed the old unprefixed `--color-*` aliases entirely — use `--w-color-*` only.**
+`core/templates/adl/load_stations_oscar.html` still uses `var(--color-border, …)`,
+`var(--color-positive, …)` and friends; those resolve to nothing and silently render their hardcoded
+hex fallbacks. Fix on sight.
+
+Key `--w-color-*` tokens for admin templates:
+
+- Borders: `--w-color-border-furniture`
+- Muted text / secondary: `--w-color-grey-400`, `--w-color-text-meta`
+- Subtle backgrounds / panel header backgrounds: `--w-color-grey-50`, `--w-color-grey-100`
+- Menus: `--w-color-surface-menus`, `--w-color-surface-field`, `--w-color-surface-page`
+- Labels / primary text: `--w-color-text-label`
+- White: `--w-color-white`
+- Status colours: `--w-color-info-100`, `--w-color-positive-100`, `--w-color-warning-100`, `--w-color-critical-200`
+- Brand/action colours: `--w-color-primary`, `--w-color-secondary`
+
+Using the tokens rather than hexes is what makes a page follow Wagtail's dark mode instead of
+drifting from it.
+
+## Known debt
+
+These predate the conventions and are recorded so they read as debt, not precedent:
+
+- **Inline `style="` attributes** survive in roughly 20 templates — worst are
+  `core/templates/core/dispatch_channel_station_links.html` (17) and
+  `core/templates/core/dispatch_channel_locks.html` (7), where the status pills are inline-styled
+  hexes (`#1f7d51` / `#d9303e` / `#666`).
+- **Three incompatible status-badge conventions** coexist: BEM `.status-badge` with copy-pasted CSS
+  (`core/templates/core/panels/sl_collection_status.html`), the inline-styled pills above, and
+  Wagtail CSS vars + icons (`monitoring/templates/monitoring/network_monitoring.html`). Wagtail's own
+  `{% status %}` / `w-status` component is used nowhere. New pages should use the shared stylesheet;
+  retrofitting the three is a separate piece of work.
+- **No `insert_global_admin_css` hook exists yet**, so there is nowhere for shared admin CSS to live.
+  Adding it is the prerequisite for both bullets above.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,3 +94,18 @@ Check these files when working on the relevant areas:
 | Topic                                     | File                                                                             |
 |-------------------------------------------|----------------------------------------------------------------------------------|
 | Architectural patterns & design decisions | [.claude/docs/architectural_patterns.md](.claude/docs/architectural_patterns.md) |
+| HTML template conventions (Django/Wagtail) | [.claude/docs/template_conventions.md](.claude/docs/template_conventions.md) |
+
+## Agent skills
+
+### Issue tracker
+
+Issues live in GitHub Issues on `wmo-raf/adl`, driven via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+The five canonical triage roles, each label string equal to its name. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
Adds the per-repo configuration the engineering skills assume, plus a written-down convention for Django/Wagtail templates. Documentation only — no runtime code touched.

## `docs/agents/`

Records practice rather than changing it. Issues already live in GitHub Issues, and the wayfinding mechanics described (map labelled `wayfinder:map`, tickets as sub-issues, blocking via GitHub's native issue dependencies) are what #150 has been using all along — it just stops being re-inferred every session.

- `issue-tracker.md` — GitHub via `gh`. "PRs as a request surface" is set to **no**; flip the flag in the file if external PRs should ever enter the triage queue.
- `triage-labels.md` — the five canonical triage roles, each label string equal to its name. `ready-for-agent` and `wontfix` already exist on the repo with exactly these strings, so only `needs-triage`, `needs-info` and `ready-for-human` would be created on first use.
- `domain.md` — single-context layout.

No `CONTEXT.md` and no `docs/adr/` are created here. Those get written lazily, when a term or a decision is actually pinned down.

## `.claude/docs/template_conventions.md`

Adapted from a sibling project, checked against this repo rather than copied. The admin-page rule already holds — 20+ templates extend `wagtailadmin/generic/base.html`. The rest is adjusted to what is actually here:

- CSS table repointed: ADL has one token context (`--w-color-*`), with Vue components styling themselves through PrimeVue. No project-branded token namespace, and the doc says not to invent one.
- `config/templates/wagtailadmin/base.html` documented as the one legitimate exception to "never extend `wagtailadmin/base.html`" — it *is* the base override, injecting the logo and version.
- Reference examples repointed at `dispatch_channel_locks.html` and `connection_list.html`.

### Known debt, recorded so it reads as debt rather than precedent

- **~20 templates carry inline `style=` attributes** — worst are `dispatch_channel_station_links.html` (17) and `dispatch_channel_locks.html` (7), where status pills are inline hexes.
- **Three incompatible status-badge conventions coexist**, and Wagtail's own `{% status %}` component is used nowhere.
- **No `insert_global_admin_css` hook exists**, so there is currently nowhere for shared admin CSS to live. That hook is a prerequisite for #161's shared status-badge stylesheet.
- `core/templates/adl/load_stations_oscar.html` still uses Wagtail 6's unprefixed `var(--color-*)` aliases, which Wagtail 7 deleted — it has been silently rendering its hex fallbacks.

Nothing is retrofitted in this PR; the debt list is the map for doing so later.