### PR TITLE
Prefactor: one shared per-station status computation

### DIFF
--- a/adl/src/adl/monitoring/status.py
+++ b/adl/src/adl/monitoring/status.py
@@ -1,0 +1,132 @@
+"""Shared per-station status computation.
+
+The pull-side (network connection) and push-side (dispatch channel) activity
+views both render a per-station pipeline status and data status. This module
+is the one computation both consume — and the seam anything else that needs
+the same verdict (the per-connection diagnostic) should read from, so they
+cannot disagree about the same station.
+
+Everything here works on plain domain objects and timestamps — no view, no
+request — so it is callable from tasks, management commands and templates.
+"""
+
+from dataclasses import dataclass
+from datetime import timedelta
+
+from django.utils import timezone as dj_timezone
+
+ACTIVE = "active"
+WARNING = "warning"
+ERROR = "error"
+
+
+@dataclass(frozen=True)
+class StatusThresholds:
+    """Time budgets a station is judged against.
+
+    ``pipeline_tolerance`` is how long we tolerate silence from the scheduled
+    job before it counts as stopped. The two freshness limits bound how old
+    the station's most recent data may be before it degrades.
+    """
+
+    pipeline_tolerance: timedelta
+    freshness_warning_limit: timedelta
+    freshness_error_limit: timedelta
+
+
+@dataclass(frozen=True)
+class StationStatus:
+    pipeline_status: str
+    data_status: str
+
+    @property
+    def overall_status(self):
+        """Worst of the two axes — what the summary counters roll up."""
+        if self.pipeline_status == ERROR or self.data_status == ERROR:
+            return ERROR
+        if self.pipeline_status == WARNING or self.data_status == WARNING:
+            return WARNING
+        return ACTIVE
+
+
+def connection_thresholds(connection):
+    """Thresholds for a pull-side (ingestion) connection."""
+    pipeline_tolerance = timedelta(minutes=connection.interval * 3)
+
+    if connection.is_daily_data:
+        # Daily: Active < 26h, Warning < 48h, Error > 48h
+        freshness_warning_limit = timedelta(hours=26)
+        freshness_error_limit = timedelta(hours=48)
+    else:
+        # High Frequency: Active < 4x interval, Warning < 12x interval
+        freshness_warning_limit = timedelta(minutes=connection.interval * 4)
+        freshness_error_limit = timedelta(minutes=connection.interval * 12)
+
+    return StatusThresholds(
+        pipeline_tolerance=pipeline_tolerance,
+        freshness_warning_limit=freshness_warning_limit,
+        freshness_error_limit=freshness_error_limit,
+    )
+
+
+def dispatch_channel_thresholds(channel):
+    """Thresholds for a push-side (dispatch) channel.
+
+    Aggregating channels are inherently behind by the size of their window,
+    so that window (plus processing slack) is added to the freshness limits.
+    """
+    check_interval = channel.data_check_interval
+
+    # 3 missed cycles means the scheduler is stuck
+    pipeline_tolerance = timedelta(minutes=check_interval * 3)
+
+    base_warning_minutes = check_interval * 4
+    base_error_minutes = check_interval * 12
+
+    aggregation_offset = timedelta(0)
+    if channel.send_aggregated_data:
+        if channel.aggregation_period == "hourly":
+            aggregation_offset = timedelta(hours=2)
+        elif channel.aggregation_period == "daily":  # Future proofing
+            aggregation_offset = timedelta(days=1)
+
+        # Extra buffer: aggregation runs *after* the period closes.
+        aggregation_offset += timedelta(minutes=5)
+
+    return StatusThresholds(
+        pipeline_tolerance=pipeline_tolerance,
+        freshness_warning_limit=timedelta(minutes=base_warning_minutes) + aggregation_offset,
+        freshness_error_limit=timedelta(minutes=base_error_minutes) + aggregation_offset,
+    )
+
+
+def compute_station_status(last_check, last_check_success, last_data_time, thresholds, now=None):
+    """Status of one station from its latest activity.
+
+    ``last_check`` / ``last_check_success`` describe the most recent run of the
+    scheduled job for this station (a pull collection or a push attempt);
+    ``last_data_time`` is the timestamp of its most recent data (an observation
+    collected, or an observation sent). Any of them may be ``None``.
+    """
+    now = now or dj_timezone.now()
+
+    pipeline_status = WARNING  # Default if never checked
+    if last_check:
+        if not last_check_success:
+            pipeline_status = ERROR  # Last run crashed
+        elif now - last_check > thresholds.pipeline_tolerance:
+            pipeline_status = WARNING  # Last run ok, but scheduler stopped
+        else:
+            pipeline_status = ACTIVE  # Healthy
+
+    data_status = WARNING  # Default if no data
+    if last_data_time:
+        data_age = now - last_data_time
+        if data_age <= thresholds.freshness_warning_limit:
+            data_status = ACTIVE
+        elif data_age <= thresholds.freshness_error_limit:
+            data_status = WARNING
+        else:
+            data_status = ERROR  # Data is stale
+
+    return StationStatus(pipeline_status=pipeline_status, data_status=data_status)

--- a/adl/src/adl/monitoring/tests.py
+++ b/adl/src/adl/monitoring/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/adl/src/adl/monitoring/tests/test_activity_views.py
+++ b/adl/src/adl/monitoring/tests/test_activity_views.py
@@ -1,0 +1,157 @@
+"""The two activity views must render the shared status computation.
+
+These are wiring tests, not a second copy of the status rules — those live in
+``test_status``. What is asserted here is that each view feeds the right
+domain rows into the helper and renders what comes back.
+"""
+
+from datetime import timedelta
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone as dj_timezone
+
+from adl.core.models import StationChannelDispatchStatus
+from adl.core.registries import plugin_registry
+from adl.core.tests.factories import (
+    NetworkConnectionFactory,
+    StationLinkFactory,
+    Wis2BoxUploadFactory,
+)
+from adl.core.tests.helpers import make_test_plugin
+from adl.monitoring.models import StationLinkActivityLog
+
+
+class ActivityViewStatusTestCase(TestCase):
+    def setUp(self):
+        self.now = dj_timezone.now()
+        # The views live under the Wagtail admin URLs, so they need admin access.
+        user = get_user_model().objects.create_superuser(
+            username="monitor", email="monitor@example.com", password="pw"
+        )
+        self.client.force_login(user)
+
+    def ago(self, **kwargs):
+        return self.now - timedelta(**kwargs)
+
+
+class NetworkConnectionActivityViewTests(ActivityViewStatusTestCase):
+    def setUp(self):
+        super().setUp()
+        # 15 min interval -> 45 min pipeline tolerance, 60 min / 180 min freshness
+        # The view reports the connection's plugin label, so the stub must be registered.
+        plugin = make_test_plugin()
+        plugin_registry.register(plugin)
+        self.addCleanup(plugin_registry.unregister, plugin)
+
+        self.connection = NetworkConnectionFactory(plugin_processing_interval=15, is_daily_data=False)
+        self.station_link = StationLinkFactory(network_connection=self.connection)
+
+    def log(self, time, success=True):
+        StationLinkActivityLog.objects.create(
+            station_link=self.station_link, direction="pull", time=time, success=success
+        )
+
+    def get(self):
+        response = self.client.get(
+            reverse("network_connection_activity", args=(self.connection.id,))
+        )
+        self.assertEqual(response.status_code, 200)
+        return response.data
+
+    def test_never_checked_station_warns(self):
+        data = self.get()
+
+        station = data["stations"][0]
+        self.assertEqual(station["pipeline_status"], "warning")
+        self.assertEqual(station["data_status"], "warning")
+        self.assertEqual(data["summary"], {"active": 0, "warning": 1, "error": 0})
+
+    def test_failed_last_run_is_an_error(self):
+        self.log(self.ago(minutes=5), success=False)
+
+        data = self.get()
+
+        self.assertEqual(data["stations"][0]["pipeline_status"], "error")
+        self.assertEqual(data["summary"], {"active": 0, "warning": 0, "error": 1})
+
+    def test_successful_run_beyond_tolerance_warns(self):
+        self.log(self.ago(minutes=50))
+
+        data = self.get()
+
+        self.assertEqual(data["stations"][0]["pipeline_status"], "warning")
+
+    def test_recent_successful_run_is_active(self):
+        self.log(self.ago(minutes=5))
+
+        data = self.get()
+
+        self.assertEqual(data["stations"][0]["pipeline_status"], "active")
+
+
+class DispatchChannelMonitoringViewTests(ActivityViewStatusTestCase):
+    def setUp(self):
+        super().setUp()
+        # 10 min check interval -> 30 min pipeline tolerance, 40 min / 120 min freshness
+        self.channel = Wis2BoxUploadFactory(data_check_interval=10, send_aggregated_data=False)
+        self.station_link = StationLinkFactory()
+        self.channel.network_connections.add(self.station_link.network_connection)
+
+    def log(self, time, success=True):
+        StationLinkActivityLog.objects.create(
+            station_link=self.station_link,
+            dispatch_channel=self.channel,
+            direction="push",
+            time=time,
+            success=success,
+        )
+
+    def sent(self, time):
+        StationChannelDispatchStatus.objects.create(
+            channel=self.channel, station=self.station_link.station, last_sent_obs_time=time
+        )
+
+    def get(self):
+        response = self.client.get(reverse("dispatch_activity", args=(self.channel.id,)))
+        self.assertEqual(response.status_code, 200)
+        return response.data
+
+    def test_never_attempted_station_warns(self):
+        data = self.get()
+
+        station = data["stations"][0]
+        self.assertEqual(station["pipeline_status"], "warning")
+        self.assertEqual(station["data_status"], "warning")
+        self.assertEqual(data["summary"], {"active": 0, "warning": 1, "error": 0})
+
+    def test_failed_attempt_is_an_error(self):
+        self.log(self.ago(minutes=5), success=False)
+        self.sent(self.ago(minutes=5))
+
+        data = self.get()
+
+        self.assertEqual(data["stations"][0]["pipeline_status"], "error")
+        self.assertEqual(data["stations"][0]["data_status"], "active")
+        self.assertEqual(data["summary"], {"active": 0, "warning": 0, "error": 1})
+
+    def test_recent_attempt_and_fresh_send_is_active(self):
+        self.log(self.ago(minutes=5))
+        self.sent(self.ago(minutes=5))
+
+        data = self.get()
+
+        station = data["stations"][0]
+        self.assertEqual(station["pipeline_status"], "active")
+        self.assertEqual(station["data_status"], "active")
+        self.assertEqual(data["summary"], {"active": 1, "warning": 0, "error": 0})
+
+    def test_stale_send_is_a_data_error(self):
+        self.log(self.ago(minutes=5))
+        self.sent(self.ago(minutes=200))
+
+        data = self.get()
+
+        self.assertEqual(data["stations"][0]["data_status"], "error")
+        self.assertEqual(data["summary"], {"active": 0, "warning": 0, "error": 1})

--- a/adl/src/adl/monitoring/tests/test_status.py
+++ b/adl/src/adl/monitoring/tests/test_status.py
@@ -1,0 +1,183 @@
+from datetime import timedelta
+
+from django.test import TestCase
+from django.utils import timezone as dj_timezone
+
+from adl.core.tests.factories import NetworkConnectionFactory, Wis2BoxUploadFactory
+from adl.monitoring.status import (
+    ACTIVE,
+    ERROR,
+    WARNING,
+    StatusThresholds,
+    compute_station_status,
+    connection_thresholds,
+    dispatch_channel_thresholds,
+)
+
+# 15 min pipeline tolerance, 20 min / 60 min freshness — round numbers to
+# make the boundary assertions below readable.
+THRESHOLDS = StatusThresholds(
+    pipeline_tolerance=timedelta(minutes=15),
+    freshness_warning_limit=timedelta(minutes=20),
+    freshness_error_limit=timedelta(minutes=60),
+)
+
+
+class ComputeStationStatusTests(TestCase):
+    def setUp(self):
+        self.now = dj_timezone.now()
+
+    def status(self, last_check=None, last_check_success=True, last_data_time=None):
+        return compute_station_status(
+            last_check=last_check,
+            last_check_success=last_check_success,
+            last_data_time=last_data_time,
+            thresholds=THRESHOLDS,
+            now=self.now,
+        )
+
+    def ago(self, **kwargs):
+        return self.now - timedelta(**kwargs)
+
+    def test_healthy_station_is_active_on_both_axes(self):
+        status = self.status(last_check=self.ago(minutes=2), last_data_time=self.ago(minutes=5))
+
+        self.assertEqual(status.pipeline_status, ACTIVE)
+        self.assertEqual(status.data_status, ACTIVE)
+        self.assertEqual(status.overall_status, ACTIVE)
+
+    def test_never_checked_station_warns_on_both_axes(self):
+        status = self.status(last_check=None, last_data_time=None)
+
+        self.assertEqual(status.pipeline_status, WARNING)
+        self.assertEqual(status.data_status, WARNING)
+        self.assertEqual(status.overall_status, WARNING)
+
+    def test_last_run_failed_is_a_pipeline_error(self):
+        status = self.status(
+            last_check=self.ago(minutes=2),
+            last_check_success=False,
+            last_data_time=self.ago(minutes=5),
+        )
+
+        self.assertEqual(status.pipeline_status, ERROR)
+        self.assertEqual(status.data_status, ACTIVE)
+        self.assertEqual(status.overall_status, ERROR)
+
+    def test_failed_run_outranks_staleness_of_the_check_itself(self):
+        # An old *and* failed check is an error, not a scheduler warning.
+        status = self.status(last_check=self.ago(hours=5), last_check_success=False)
+
+        self.assertEqual(status.pipeline_status, ERROR)
+
+    def test_scheduler_stopped_warns_even_though_last_run_succeeded(self):
+        status = self.status(last_check=self.ago(minutes=16), last_data_time=self.ago(minutes=5))
+
+        self.assertEqual(status.pipeline_status, WARNING)
+        self.assertEqual(status.data_status, ACTIVE)
+        self.assertEqual(status.overall_status, WARNING)
+
+    def test_check_exactly_at_tolerance_is_still_active(self):
+        status = self.status(last_check=self.ago(minutes=15))
+
+        self.assertEqual(status.pipeline_status, ACTIVE)
+
+    def test_stale_data_is_a_data_error(self):
+        status = self.status(last_check=self.ago(minutes=2), last_data_time=self.ago(minutes=61))
+
+        self.assertEqual(status.pipeline_status, ACTIVE)
+        self.assertEqual(status.data_status, ERROR)
+        self.assertEqual(status.overall_status, ERROR)
+
+    def test_ageing_data_warns_before_it_errors(self):
+        status = self.status(last_check=self.ago(minutes=2), last_data_time=self.ago(minutes=30))
+
+        self.assertEqual(status.data_status, WARNING)
+        self.assertEqual(status.overall_status, WARNING)
+
+    def test_data_exactly_at_each_freshness_limit_takes_the_kinder_status(self):
+        self.assertEqual(self.status(last_data_time=self.ago(minutes=20)).data_status, ACTIVE)
+        self.assertEqual(self.status(last_data_time=self.ago(minutes=60)).data_status, WARNING)
+
+    def test_missing_data_warns_even_when_the_pipeline_is_healthy(self):
+        status = self.status(last_check=self.ago(minutes=2), last_data_time=None)
+
+        self.assertEqual(status.pipeline_status, ACTIVE)
+        self.assertEqual(status.data_status, WARNING)
+        self.assertEqual(status.overall_status, WARNING)
+
+    def test_error_on_either_axis_wins_the_roll_up(self):
+        status = self.status(
+            last_check=self.ago(minutes=16),  # warning
+            last_data_time=self.ago(minutes=61),  # error
+        )
+
+        self.assertEqual(status.overall_status, ERROR)
+
+    def test_now_defaults_to_the_current_time(self):
+        status = compute_station_status(
+            last_check=dj_timezone.now(),
+            last_check_success=True,
+            last_data_time=dj_timezone.now(),
+            thresholds=THRESHOLDS,
+        )
+
+        self.assertEqual(status.overall_status, ACTIVE)
+
+
+class ConnectionThresholdsTests(TestCase):
+    def test_high_frequency_limits_scale_with_the_interval(self):
+        connection = NetworkConnectionFactory(plugin_processing_interval=15, is_daily_data=False)
+
+        thresholds = connection_thresholds(connection)
+
+        self.assertEqual(thresholds.pipeline_tolerance, timedelta(minutes=45))
+        self.assertEqual(thresholds.freshness_warning_limit, timedelta(minutes=60))
+        self.assertEqual(thresholds.freshness_error_limit, timedelta(minutes=180))
+
+    def test_daily_connections_use_fixed_freshness_limits(self):
+        connection = NetworkConnectionFactory(plugin_processing_interval=60, is_daily_data=True)
+
+        thresholds = connection_thresholds(connection)
+
+        self.assertEqual(thresholds.pipeline_tolerance, timedelta(minutes=180))
+        self.assertEqual(thresholds.freshness_warning_limit, timedelta(hours=26))
+        self.assertEqual(thresholds.freshness_error_limit, timedelta(hours=48))
+
+
+class DispatchChannelThresholdsTests(TestCase):
+    def test_limits_scale_with_the_check_interval(self):
+        channel = Wis2BoxUploadFactory(data_check_interval=10, send_aggregated_data=False)
+
+        thresholds = dispatch_channel_thresholds(channel)
+
+        self.assertEqual(thresholds.pipeline_tolerance, timedelta(minutes=30))
+        self.assertEqual(thresholds.freshness_warning_limit, timedelta(minutes=40))
+        self.assertEqual(thresholds.freshness_error_limit, timedelta(minutes=120))
+
+    def test_hourly_aggregation_buys_the_window_plus_slack(self):
+        channel = Wis2BoxUploadFactory(
+            data_check_interval=10,
+            send_aggregated_data=True,
+            aggregation_period="hourly",
+        )
+
+        thresholds = dispatch_channel_thresholds(channel)
+
+        offset = timedelta(hours=2, minutes=5)
+        self.assertEqual(thresholds.pipeline_tolerance, timedelta(minutes=30))
+        self.assertEqual(thresholds.freshness_warning_limit, timedelta(minutes=40) + offset)
+        self.assertEqual(thresholds.freshness_error_limit, timedelta(minutes=120) + offset)
+
+    def test_daily_aggregation_buys_a_day_plus_slack(self):
+        channel = Wis2BoxUploadFactory(
+            data_check_interval=10,
+            send_aggregated_data=True,
+            aggregation_period="daily",
+        )
+
+        thresholds = dispatch_channel_thresholds(channel)
+
+        offset = timedelta(days=1, minutes=5)
+        self.assertEqual(thresholds.freshness_warning_limit, timedelta(minutes=40) + offset)
+        self.assertEqual(thresholds.freshness_error_limit, timedelta(minutes=120) + offset)

--- a/adl/src/adl/monitoring/views/activity.py
+++ b/adl/src/adl/monitoring/views/activity.py
@@ -1,5 +1,3 @@
-from datetime import timedelta
-
 from django.contrib.humanize.templatetags.humanize import naturaltime
 from django.db.models import OuterRef, Subquery
 from django.shortcuts import get_object_or_404
@@ -15,6 +13,11 @@ from adl.core.models import (
     StationChannelDispatchStatus
 )
 from adl.monitoring.models import StationLinkActivityLog
+from adl.monitoring.status import (
+    compute_station_status,
+    connection_thresholds,
+    dispatch_channel_thresholds,
+)
 
 
 class NetworkConnectionActivityView(APIView):
@@ -48,22 +51,10 @@ class NetworkConnectionActivityView(APIView):
         )
         
         # --- SETUP THRESHOLDS ---
-        
+
         now = dj_timezone.now()
-        
-        # A. Pipeline Tolerance (3x the configured interval)
-        pipeline_tolerance = timedelta(minutes=connection.interval * 3)
-        
-        # B. Data Freshness Thresholds
-        if connection.is_daily_data:
-            # Daily: Active < 26h, Warning < 48h, Error > 48h
-            freshness_warning_limit = timedelta(hours=26)
-            freshness_error_limit = timedelta(hours=48)
-        else:
-            # High Frequency: Active < 4x interval, Warning < 12x interval
-            freshness_warning_limit = timedelta(minutes=connection.interval * 4)
-            freshness_error_limit = timedelta(minutes=connection.interval * 12)
-        
+        thresholds = connection_thresholds(connection)
+
         # --- PROCESS DATA & CALCULATE STATUS ---
         
         stations_count = station_links.count()
@@ -72,37 +63,19 @@ class NetworkConnectionActivityView(APIView):
         data_viewer_url_base = reverse("viewer_table")
         
         for sl in station_links:
-            # 1. Determine PIPELINE Status
-            pipeline_status = "warning"  # Default if never checked
-            if sl.last_check:
-                time_since_check = now - sl.last_check
-                if not sl.last_log_success:
-                    pipeline_status = "error"  # Last run crashed
-                elif time_since_check > pipeline_tolerance:
-                    pipeline_status = "warning"  # Last run ok, but scheduler stopped
-                else:
-                    pipeline_status = "active"  # Healthy
-            
-            # 2. Determine DATA Status
-            data_status = "warning"  # Default if no data
-            if sl.last_collected:
-                data_age = now - sl.last_collected
-                if data_age <= freshness_warning_limit:
-                    data_status = "active"
-                elif data_age <= freshness_error_limit:
-                    data_status = "warning"
-                else:
-                    data_status = "error"  # Data is stale
-            
-            # 3. Update Global Summary (Worst-case logic)
-            if pipeline_status == "error" or data_status == "error":
-                summary["error"] += 1
-            elif pipeline_status == "warning" or data_status == "warning":
-                summary["warning"] += 1
-            else:
-                summary["active"] += 1
-            
-            # 4. Generate URLs
+            # 1. Determine PIPELINE and DATA Status
+            status = compute_station_status(
+                last_check=sl.last_check,
+                last_check_success=sl.last_log_success,
+                last_data_time=sl.last_collected,
+                thresholds=thresholds,
+                now=now,
+            )
+
+            # 2. Update Global Summary (Worst-case logic)
+            summary[status.overall_status] += 1
+
+            # 3. Generate URLs
             monitor_url = reverse("station_link_monitoring", args=(sl.id,)) + "?direction=pull"
             
             # Format outputs
@@ -111,8 +84,8 @@ class NetworkConnectionActivityView(APIView):
                 "name": sl.station.name,
                 
                 # Dual Statuses
-                "pipeline_status": pipeline_status,
-                "data_status": data_status,
+                "pipeline_status": status.pipeline_status,
+                "data_status": status.data_status,
                 
                 # Pipeline Data
                 "last_check": sl.last_check,
@@ -165,38 +138,10 @@ class DispatchChannelMonitoringView(APIView):
         )
         
         # --- 2. SETUP THRESHOLDS ---
-        
+
         now = dj_timezone.now()
-        check_interval = channel.data_check_interval
-        
-        # A. Pipeline Tolerance (Is the job running?)
-        # Standard: 3 missed cycles means the scheduler is stuck
-        pipeline_tolerance = timedelta(minutes=check_interval * 3)
-        
-        # B. Data Freshness (Is the data current?)
-        
-        # Base limits based on check interval
-        base_warning_minutes = check_interval * 4
-        base_error_minutes = check_interval * 12
-        
-        # Calculate Aggregation Offset
-        aggregation_offset = timedelta(0)
-        
-        if channel.send_aggregated_data:
-            # If aggregating, the data is inherently old by the size of the window.
-            # We add this window to the allowed tolerance.
-            if channel.aggregation_period == 'hourly':
-                aggregation_offset = timedelta(hours=2)
-            elif channel.aggregation_period == 'daily':  # Future proofing
-                aggregation_offset = timedelta(days=1)
-            
-            # Note: We add an extra buffer because aggregation usually happens
-            # *after* the period closes + processing time.
-            aggregation_offset += timedelta(minutes=5)
-        
-        freshness_warning_limit = timedelta(minutes=base_warning_minutes) + aggregation_offset
-        freshness_error_limit = timedelta(minutes=base_error_minutes) + aggregation_offset
-        
+        thresholds = dispatch_channel_thresholds(channel)
+
         # --- 3. PROCESS DATA ---
         
         stations_output = []
@@ -204,37 +149,17 @@ class DispatchChannelMonitoringView(APIView):
         stations_count = station_links.count()
         
         for sl in station_links:
-            # --- Pipeline Status ---
-            pipeline_status = "warning"
-            if sl.last_attempt:
-                time_since_attempt = now - sl.last_attempt
-                if not sl.last_attempt_success:
-                    pipeline_status = "error"
-                elif time_since_attempt > pipeline_tolerance:
-                    pipeline_status = "warning"
-                else:
-                    pipeline_status = "active"
-            
-            # --- Data Status (With Aggregation Logic) ---
-            data_status = "warning"
-            if sl.last_sent_obs:
-                data_age = now - sl.last_sent_obs
-                
-                if data_age <= freshness_warning_limit:
-                    data_status = "active"
-                elif data_age <= freshness_error_limit:
-                    data_status = "warning"
-                else:
-                    data_status = "error"
-            
+            status = compute_station_status(
+                last_check=sl.last_attempt,
+                last_check_success=sl.last_attempt_success,
+                last_data_time=sl.last_sent_obs,
+                thresholds=thresholds,
+                now=now,
+            )
+
             # --- Summary ---
-            if pipeline_status == "error" or data_status == "error":
-                summary["error"] += 1
-            elif pipeline_status == "warning" or data_status == "warning":
-                summary["warning"] += 1
-            else:
-                summary["active"] += 1
-            
+            summary[status.overall_status] += 1
+
             monitor_url = reverse("station_link_monitoring", args=(sl.id,)) + f"?direction=push&channel={channel.id}"
             
             stations_output.append({
@@ -243,8 +168,8 @@ class DispatchChannelMonitoringView(APIView):
                 "connection_name": sl.network_connection.name,
                 "connection_id": sl.network_connection.id,
                 
-                "pipeline_status": pipeline_status,
-                "data_status": data_status,
+                "pipeline_status": status.pipeline_status,
+                "data_status": status.data_status,
                 "last_check": sl.last_attempt,
                 "last_check_human": naturaltime(sl.last_attempt) if sl.last_attempt else None,
                 "last_collected": sl.last_sent_obs,


### PR DESCRIPTION
Closes #172.

## What

The pull-side (`NetworkConnectionActivityView`) and push-side (`DispatchChannelMonitoringView`) activity views each computed a station's `pipeline_status` and `data_status` in near-duplicate blocks. This extracts that into one shared computation in `adl/monitoring/status.py` that both views consume.

This is the load-bearing prefactor for #171: the per-connection diagnostic page and the monitoring dashboard panel must never disagree about the same station's status, and one computation is the only durable way to guarantee that.

## API

- `compute_station_status(last_check, last_check_success, last_data_time, thresholds, now=None)` → a frozen `StationStatus(pipeline_status, data_status)` with an `overall_status` property carrying the worst-of-two roll-up.
- `connection_thresholds(connection)` / `dispatch_channel_thresholds(channel)` build the `StatusThresholds` each side is judged against — the daily-data limits on the pull side, the aggregation offset on the push side.

Everything takes plain domain objects and timestamps. `status.py` imports nothing from views or DRF, so it is callable from tasks, management commands and templates.

## No behaviour change

Thresholds, boundary comparisons (strict `>` on pipeline tolerance, `<=` on both freshness limits), both `warning` defaults, the precedence of a failed run over a stale check, and the summary roll-up are all carried over verbatim. Response payload keys are byte-identical, so `NetworkActivity.vue` and `DispatchChannelActivity.vue` needed no change.

## Tests

`monitoring/tests.py` (an empty placeholder) becomes a `tests/` package:

- `test_status.py` — 17 tests on the helper directly: healthy, never-checked, last-run-failed, scheduler-stopped, stale-data, plus both freshness boundaries and both threshold builders.
- `test_activity_views.py` — 8 tests pinning the wiring, that each view feeds the right rows in and renders what comes back.

Full suite: 95 tests, OK.

## Known limitation for the follow-up ticket

There is no station-link-level entry point — a caller picks `connection_thresholds` vs `dispatch_channel_thresholds` itself, so it is possible to pair a pull station link with dispatch thresholds and get a silently wrong answer. Building that wrapper now, with no second consumer, would be premature; the diagnostic-page ticket should either add it or be careful at the call site.