### PR TITLE
feat: one stale-activity-log sweep serving both directions, off the ingestion queue

### DIFF
--- a/adl/src/adl/config/settings/base.py
+++ b/adl/src/adl/config/settings/base.py
@@ -306,8 +306,8 @@ CELERY_TASK_ROUTES = {
     'adl.core.tasks.process_station_link_batch': {'queue': 'adl'},
     'adl.core.tasks.perform_channel_dispatch': {'queue': 'dispatch'},
     'adl.core.tasks.dispatch_station': {'queue': 'dispatch'},
-    # The sweep watches the ingestion queue for starvation, so it must not
-    # share it — routed with dispatch, which runs on its own worker
+    # The sweep records rows a starved or dead ingestion worker left behind,
+    # so it must not share that queue — routed with dispatch, its own worker
     'adl.core.tasks.sweep_stale_activity_logs': {'queue': 'dispatch'},
 }
 

--- a/adl/src/adl/config/settings/base.py
+++ b/adl/src/adl/config/settings/base.py
@@ -306,7 +306,9 @@ CELERY_TASK_ROUTES = {
     'adl.core.tasks.process_station_link_batch': {'queue': 'adl'},
     'adl.core.tasks.perform_channel_dispatch': {'queue': 'dispatch'},
     'adl.core.tasks.dispatch_station': {'queue': 'dispatch'},
-    'adl.core.tasks.sweep_stale_dispatch_logs': {'queue': 'dispatch'},
+    # The sweep watches the ingestion queue for starvation, so it must not
+    # share it — routed with dispatch, which runs on its own worker
+    'adl.core.tasks.sweep_stale_activity_logs': {'queue': 'dispatch'},
 }
 
 CACHES = {

--- a/adl/src/adl/core/registries.py
+++ b/adl/src/adl/core/registries.py
@@ -757,17 +757,14 @@ class Plugin(Instance):
         from django.core.cache import cache
         from adl.monitoring.models import StationLinkActivityLog
         from adl.core.tasks import (
-            INGEST_LOCK_TTL_MARGIN_SECONDS,
-            INGEST_TIME_LIMIT_GRACE_SECONDS,
             ingest_station_lock_key,
+            ingest_timeout_budget_seconds,
         )
         log = self.get_logger()
 
         lock_key = ingest_station_lock_key(station_link.id)
         if not bypass_lock:
-            lock_ttl = (station_link.network_connection.ingest_timeout_seconds
-                        + INGEST_TIME_LIMIT_GRACE_SECONDS
-                        + INGEST_LOCK_TTL_MARGIN_SECONDS)
+            lock_ttl = ingest_timeout_budget_seconds(station_link.network_connection)
             if not cache.add(lock_key, "locked", timeout=lock_ttl):
                 log.warning("Station link %s is still processing. Skipping...", station_link)
                 StationLinkActivityLog.objects.create(

--- a/adl/src/adl/core/tasks.py
+++ b/adl/src/adl/core/tasks.py
@@ -108,8 +108,8 @@ def setup_periodic_tasks(sender, **kwargs):
     )
     sender.add_periodic_task(
         300.0,
-        sweep_stale_dispatch_logs.s(),
-        name="sweep-stale-dispatch-logs-every-5-minutes",
+        sweep_stale_activity_logs.s(),
+        name="sweep-stale-activity-logs-every-5-minutes",
     )
 
 
@@ -541,41 +541,58 @@ def dispatch_station(self, channel_id, station_link_id):
         log.save()
 
 
-@shared_task(name="adl.core.tasks.sweep_stale_dispatch_logs")
-def sweep_stale_dispatch_logs():
+@shared_task(name="adl.core.tasks.sweep_stale_activity_logs")
+def sweep_stale_activity_logs():
     """
-    Mark push activity logs stranded in STARTED as failed.
+    Mark activity logs stranded in STARTED — in either direction — as failed.
 
-    A dispatch that dies with the worker (hard time limit, OOM, container
-    kill) never reaches the code that finalizes its activity log, leaving the
-    row in STARTED forever. Rows older than their channel's dispatch timeout
-    plus the same grace + margin used for the station lock TTL cannot still
-    be running, so they are swept to FAILED.
+    A run that dies with its worker (hard time limit, OOM, container kill)
+    never reaches the code that finalizes its activity log, leaving the row
+    in STARTED forever. A row older than the timeout budget its own side
+    defines — the channel's dispatch timeout for push rows, the connection's
+    ingest timeout for pull rows — plus the same grace + margin used for that
+    side's lock TTL cannot still be running, so it is swept to FAILED.
     """
     from .models import DispatchChannel  # noqa: F401  (FK target must be loaded)
 
     now = dj_timezone.now()
     swept = 0
 
-    candidates = StationLinkActivityLog.objects.filter(
+    push_candidates = StationLinkActivityLog.objects.filter(
         direction="push",
         status=StationLinkActivityLog.ActivityStatus.STARTED,
         dispatch_channel__isnull=False,
+    ).select_related("dispatch_channel")
+
+    pull_candidates = StationLinkActivityLog.objects.filter(
+        direction="pull",
+        status=StationLinkActivityLog.ActivityStatus.STARTED,
+    ).select_related("station_link__network_connection")
+
+    sides = (
+        (push_candidates,
+         lambda log: log.dispatch_channel.dispatch_timeout_seconds
+                     + DISPATCH_TIME_LIMIT_GRACE_SECONDS
+                     + DISPATCH_LOCK_TTL_MARGIN_SECONDS,
+         "Dispatch worker died mid-dispatch (no completion recorded)"),
+        (pull_candidates,
+         lambda log: log.station_link.network_connection.ingest_timeout_seconds
+                     + INGEST_TIME_LIMIT_GRACE_SECONDS
+                     + INGEST_LOCK_TTL_MARGIN_SECONDS,
+         "Ingestion worker died mid-run (no completion recorded)"),
     )
 
-    for log in candidates:
-        threshold_seconds = (log.dispatch_channel.dispatch_timeout_seconds
-                             + DISPATCH_TIME_LIMIT_GRACE_SECONDS
-                             + DISPATCH_LOCK_TTL_MARGIN_SECONDS)
-        if log.time < now - timedelta(seconds=threshold_seconds):
-            log.status = StationLinkActivityLog.ActivityStatus.FAILED
-            log.success = False
-            log.message = "Dispatch worker died mid-dispatch (no completion recorded)"
-            log.save(update_fields=["status", "success", "message"])
-            swept += 1
+    for candidates, threshold_seconds, message in sides:
+        for log in candidates:
+            if log.time < now - timedelta(seconds=threshold_seconds(log)):
+                log.status = StationLinkActivityLog.ActivityStatus.FAILED
+                log.success = False
+                log.message = message
+                log.save(update_fields=["status", "success", "message"])
+                swept += 1
 
     if swept:
-        logger.warning("[DISPATCH] Swept %d stale dispatch activity log(s) to FAILED", swept)
+        logger.warning("[SWEEP] Swept %d stale activity log(s) to FAILED", swept)
 
     return swept
 

--- a/adl/src/adl/core/tasks.py
+++ b/adl/src/adl/core/tasks.py
@@ -49,6 +49,22 @@ def dispatch_station_lock_key(channel_id, station_link_id):
     return f"lock:dispatch:{channel_id}:{station_link_id}"
 
 
+# The two budgets below are shared between each side's station lock TTL and
+# the stale-activity-log sweep: a row older than the budget cannot still be
+# running, precisely because its lock would already have expired
+
+def dispatch_timeout_budget_seconds(channel):
+    return (channel.dispatch_timeout_seconds
+            + DISPATCH_TIME_LIMIT_GRACE_SECONDS
+            + DISPATCH_LOCK_TTL_MARGIN_SECONDS)
+
+
+def ingest_timeout_budget_seconds(network_connection):
+    return (network_connection.ingest_timeout_seconds
+            + INGEST_TIME_LIMIT_GRACE_SECONDS
+            + INGEST_LOCK_TTL_MARGIN_SECONDS)
+
+
 # Namespace deliberately distinct from the legacy "lock:station:" prefix:
 # locks created before TTLs existed are eternal, so they are orphaned by the
 # rename instead of migrated
@@ -452,9 +468,7 @@ def dispatch_station(self, channel_id, station_link_id):
         return
 
     lock_key = dispatch_station_lock_key(channel_id, station_link_id)
-    lock_ttl = (channel.dispatch_timeout_seconds
-                + DISPATCH_TIME_LIMIT_GRACE_SECONDS
-                + DISPATCH_LOCK_TTL_MARGIN_SECONDS)
+    lock_ttl = dispatch_timeout_budget_seconds(channel)
 
     if not cache.add(lock_key, "locked", timeout=lock_ttl):
         logger.warning("[DISPATCH] Station %s on channel %s still dispatching. Skipping...",
@@ -571,14 +585,10 @@ def sweep_stale_activity_logs():
 
     sides = (
         (push_candidates,
-         lambda log: log.dispatch_channel.dispatch_timeout_seconds
-                     + DISPATCH_TIME_LIMIT_GRACE_SECONDS
-                     + DISPATCH_LOCK_TTL_MARGIN_SECONDS,
+         lambda log: dispatch_timeout_budget_seconds(log.dispatch_channel),
          "Dispatch worker died mid-dispatch (no completion recorded)"),
         (pull_candidates,
-         lambda log: log.station_link.network_connection.ingest_timeout_seconds
-                     + INGEST_TIME_LIMIT_GRACE_SECONDS
-                     + INGEST_LOCK_TTL_MARGIN_SECONDS,
+         lambda log: ingest_timeout_budget_seconds(log.station_link.network_connection),
          "Ingestion worker died mid-run (no completion recorded)"),
     )
 

--- a/adl/src/adl/core/tests/test_activity_log_sweep.py
+++ b/adl/src/adl/core/tests/test_activity_log_sweep.py
@@ -1,0 +1,146 @@
+from datetime import timedelta
+
+from django.conf import settings
+from django.test import TestCase
+from django.utils import timezone as dj_tz
+
+from adl.core.tasks import sweep_stale_activity_logs
+from adl.monitoring.models import StationLinkActivityLog
+from .factories import NetworkConnectionFactory, StationLinkFactory, Wis2BoxUploadFactory
+
+
+class ActivityLogSweepTestCase(TestCase):
+    def setUp(self):
+        self.link = StationLinkFactory()
+        self.channel = Wis2BoxUploadFactory()
+        self.channel.network_connections.add(self.link.network_connection)
+
+    def _make_log(self, direction, age_seconds,
+                  status=StationLinkActivityLog.ActivityStatus.STARTED,
+                  link=None, channel=None):
+        return StationLinkActivityLog.objects.create(
+            time=dj_tz.now() - timedelta(seconds=age_seconds),
+            station_link=link or self.link,
+            direction=direction,
+            dispatch_channel=(channel or self.channel) if direction == "push" else None,
+            status=status,
+        )
+
+
+class SweepBothDirectionsTests(ActivityLogSweepTestCase):
+    def test_stale_push_row_swept_to_failed(self):
+        # default channel timeout 300s + 30s grace + 60s margin = 390s threshold
+        log = self._make_log("push", age_seconds=500)
+
+        swept = sweep_stale_activity_logs()
+
+        self.assertEqual(swept, 1)
+        log.refresh_from_db()
+        self.assertEqual(log.status, StationLinkActivityLog.ActivityStatus.FAILED)
+        self.assertFalse(log.success)
+        self.assertIn("worker died", log.message)
+
+    def test_stale_pull_row_swept_to_failed(self):
+        # default connection ingest timeout 300s + 30s grace + 60s margin = 390s
+        log = self._make_log("pull", age_seconds=500)
+
+        swept = sweep_stale_activity_logs()
+
+        self.assertEqual(swept, 1)
+        log.refresh_from_db()
+        self.assertEqual(log.status, StationLinkActivityLog.ActivityStatus.FAILED)
+        self.assertFalse(log.success)
+        self.assertIn("worker died", log.message)
+
+    def test_one_pass_sweeps_stale_rows_in_both_directions(self):
+        push_log = self._make_log("push", age_seconds=500)
+        pull_log = self._make_log("pull", age_seconds=500)
+
+        swept = sweep_stale_activity_logs()
+
+        self.assertEqual(swept, 2)
+        push_log.refresh_from_db()
+        pull_log.refresh_from_db()
+        self.assertEqual(push_log.status, StationLinkActivityLog.ActivityStatus.FAILED)
+        self.assertEqual(pull_log.status, StationLinkActivityLog.ActivityStatus.FAILED)
+
+
+class SweepLeavesLiveRowsAloneTests(ActivityLogSweepTestCase):
+    def test_fresh_rows_untouched_in_both_directions(self):
+        # under the 390s threshold: may legitimately still be running
+        push_log = self._make_log("push", age_seconds=100)
+        pull_log = self._make_log("pull", age_seconds=100)
+
+        swept = sweep_stale_activity_logs()
+
+        self.assertEqual(swept, 0)
+        push_log.refresh_from_db()
+        pull_log.refresh_from_db()
+        self.assertEqual(push_log.status, StationLinkActivityLog.ActivityStatus.STARTED)
+        self.assertEqual(pull_log.status, StationLinkActivityLog.ActivityStatus.STARTED)
+
+    def test_finished_rows_untouched_regardless_of_age(self):
+        finished = [
+            self._make_log(direction, age_seconds=10_000, status=status)
+            for direction in ("push", "pull")
+            for status in (StationLinkActivityLog.ActivityStatus.COMPLETED,
+                           StationLinkActivityLog.ActivityStatus.FAILED,
+                           StationLinkActivityLog.ActivityStatus.SKIPPED)
+        ]
+
+        swept = sweep_stale_activity_logs()
+
+        self.assertEqual(swept, 0)
+        for log in finished:
+            original_status = log.status
+            log.refresh_from_db()
+            self.assertEqual(log.status, original_status)
+
+
+class SweepThresholdTests(ActivityLogSweepTestCase):
+    def test_push_threshold_is_per_channel_timeout(self):
+        # same age, different channel timeouts: stale for the 30s channel
+        # (threshold 120s), still fresh for the 600s channel (threshold 690s)
+        short_channel = Wis2BoxUploadFactory(dispatch_timeout_seconds=30)
+        long_channel = Wis2BoxUploadFactory(dispatch_timeout_seconds=600)
+        stale_for_short = self._make_log("push", age_seconds=300, channel=short_channel)
+        fresh_for_long = self._make_log("push", age_seconds=300, channel=long_channel)
+
+        swept = sweep_stale_activity_logs()
+
+        self.assertEqual(swept, 1)
+        stale_for_short.refresh_from_db()
+        fresh_for_long.refresh_from_db()
+        self.assertEqual(stale_for_short.status, StationLinkActivityLog.ActivityStatus.FAILED)
+        self.assertEqual(fresh_for_long.status, StationLinkActivityLog.ActivityStatus.STARTED)
+
+    def test_pull_threshold_is_per_connection_ingest_timeout(self):
+        # same age, different ingest timeouts: stale for the 30s connection
+        # (threshold 120s), still fresh for the 600s connection (threshold 690s)
+        short_link = StationLinkFactory(
+            network_connection=NetworkConnectionFactory(ingest_timeout_seconds=30))
+        long_link = StationLinkFactory(
+            network_connection=NetworkConnectionFactory(ingest_timeout_seconds=600))
+        stale_for_short = self._make_log("pull", age_seconds=300, link=short_link)
+        fresh_for_long = self._make_log("pull", age_seconds=300, link=long_link)
+
+        swept = sweep_stale_activity_logs()
+
+        self.assertEqual(swept, 1)
+        stale_for_short.refresh_from_db()
+        fresh_for_long.refresh_from_db()
+        self.assertEqual(stale_for_short.status, StationLinkActivityLog.ActivityStatus.FAILED)
+        self.assertEqual(fresh_for_long.status, StationLinkActivityLog.ActivityStatus.STARTED)
+
+
+class SweepQueueRoutingTests(TestCase):
+    def test_sweep_is_not_routed_to_the_ingestion_queue(self):
+        route = settings.CELERY_TASK_ROUTES["adl.core.tasks.sweep_stale_activity_logs"]
+        self.assertNotEqual(route["queue"], "adl")
+        self.assertEqual(route["queue"], "dispatch")
+
+    def test_push_only_sweep_is_gone(self):
+        self.assertNotIn("adl.core.tasks.sweep_stale_dispatch_logs",
+                         settings.CELERY_TASK_ROUTES)
+        from adl.core import tasks
+        self.assertFalse(hasattr(tasks, "sweep_stale_dispatch_logs"))

--- a/adl/src/adl/core/tests/test_dispatch_queue.py
+++ b/adl/src/adl/core/tests/test_dispatch_queue.py
@@ -17,7 +17,7 @@ class DispatchQueueRoutingTests(TestCase):
         for task_name in (
                 "adl.core.tasks.perform_channel_dispatch",
                 "adl.core.tasks.dispatch_station",
-                "adl.core.tasks.sweep_stale_dispatch_logs",
+                "adl.core.tasks.sweep_stale_activity_logs",
         ):
             self.assertEqual(routes[task_name]["queue"], "dispatch", task_name)
 

--- a/adl/src/adl/core/tests/test_dispatch_tasks.py
+++ b/adl/src/adl/core/tests/test_dispatch_tasks.py
@@ -10,7 +10,6 @@ from adl.core.models import StationChannelDispatchStatus, Wis2BoxUpload
 from adl.core.tasks import (
     dispatch_station,
     perform_channel_dispatch,
-    sweep_stale_dispatch_logs,
 )
 from adl.monitoring.models import StationLinkActivityLog
 from .factories import StationLinkFactory, Wis2BoxUploadFactory
@@ -127,68 +126,8 @@ class DispatchStationLockTests(DispatchTaskTestCase):
         mock_add.assert_called_once_with(self.lock_key, "locked", timeout=390)
 
 
-class SweepStaleDispatchLogsTests(DispatchTaskTestCase):
-    def _make_push_log(self, age_seconds, status=StationLinkActivityLog.ActivityStatus.STARTED,
-                       channel=None):
-        return StationLinkActivityLog.objects.create(
-            time=dj_tz.now() - timedelta(seconds=age_seconds),
-            station_link=self.link,
-            direction="push",
-            dispatch_channel=channel or self.channel,
-            status=status,
-        )
-
-    def test_stale_started_row_swept_to_failed(self):
-        # default channel timeout 300s + 30s grace + 60s margin = 390s threshold
-        log = self._make_push_log(age_seconds=500)
-
-        swept = sweep_stale_dispatch_logs()
-
-        self.assertEqual(swept, 1)
-        log.refresh_from_db()
-        self.assertEqual(log.status, StationLinkActivityLog.ActivityStatus.FAILED)
-        self.assertFalse(log.success)
-        self.assertIn("worker died", log.message)
-
-    def test_fresh_started_row_untouched(self):
-        # under the 390s threshold: may legitimately still be running
-        log = self._make_push_log(age_seconds=100)
-
-        swept = sweep_stale_dispatch_logs()
-
-        self.assertEqual(swept, 0)
-        log.refresh_from_db()
-        self.assertEqual(log.status, StationLinkActivityLog.ActivityStatus.STARTED)
-
-    def test_finished_rows_untouched_regardless_of_age(self):
-        completed = self._make_push_log(
-            age_seconds=10_000, status=StationLinkActivityLog.ActivityStatus.COMPLETED)
-        failed = self._make_push_log(
-            age_seconds=10_000, status=StationLinkActivityLog.ActivityStatus.FAILED)
-
-        swept = sweep_stale_dispatch_logs()
-
-        self.assertEqual(swept, 0)
-        completed.refresh_from_db()
-        failed.refresh_from_db()
-        self.assertEqual(completed.status, StationLinkActivityLog.ActivityStatus.COMPLETED)
-        self.assertEqual(failed.status, StationLinkActivityLog.ActivityStatus.FAILED)
-
-    def test_threshold_is_per_channel_timeout(self):
-        # same age, different channel timeouts: stale for the 30s channel
-        # (threshold 120s), still fresh for the 600s channel (threshold 690s)
-        short_channel = Wis2BoxUploadFactory(dispatch_timeout_seconds=30)
-        long_channel = Wis2BoxUploadFactory(dispatch_timeout_seconds=600)
-        stale_for_short = self._make_push_log(age_seconds=300, channel=short_channel)
-        fresh_for_long = self._make_push_log(age_seconds=300, channel=long_channel)
-
-        swept = sweep_stale_dispatch_logs()
-
-        self.assertEqual(swept, 1)
-        stale_for_short.refresh_from_db()
-        fresh_for_long.refresh_from_db()
-        self.assertEqual(stale_for_short.status, StationLinkActivityLog.ActivityStatus.FAILED)
-        self.assertEqual(fresh_for_long.status, StationLinkActivityLog.ActivityStatus.STARTED)
+# The stale-log sweep now serves both directions — its tests live in
+# test_activity_log_sweep.py
 
 
 class CoordinatorTaskContractTests(TestCase):


### PR DESCRIPTION
Closes #175 (spec #171, decision section 5).

## What

- `sweep_stale_activity_logs` replaces the push-only `sweep_stale_dispatch_logs` and sweeps activity rows stranded in `STARTED` — in both directions — to `FAILED`, with a message naming the cause.
- Staleness thresholds derive from each side's own timeout budget: the channel's dispatch timeout for push rows, the connection's ingest timeout for pull rows, each plus the same grace and margin as that side's lock TTL. Rows younger than their threshold are left alone.
- The sweep stays routed to the `dispatch` queue, so it cannot starve with the ingestion queue whose casualties it records.
- Follow-up refactor: `dispatch_timeout_budget_seconds` / `ingest_timeout_budget_seconds` are now the single formula shared by both lock TTLs and the sweep, so the sweep provably uses the same number as the locks.

## Tests

New `adl/src/adl/core/tests/test_activity_log_sweep.py` (9 tests): both directions sweep, fresh and finished rows survive, per-channel and per-connection thresholds, routing off the ingestion queue, old task gone. Full suite: 133 tests, green.