### PR TITLE
feat: broker and queue health behind one function

### DIFF
--- a/adl/src/adl/core/broker.py
+++ b/adl/src/adl/core/broker.py
@@ -29,14 +29,14 @@ from kombu.exceptions import ChannelError
 
 from adl.config.celery import app
 
-logger = logging.getLogger(__name__)
+from .tasks import INGESTION_QUEUE_NAME, INGESTION_TASK_NAME
 
-INGESTION_QUEUE_NAME = "adl"
+logger = logging.getLogger(__name__)
 
 # The task names that constitute ingestion work on the queue — the
 # coordinator and the per-station batch it spawns
 INGESTION_TASK_NAMES = frozenset({
-    "adl.core.tasks.run_network_plugin",
+    INGESTION_TASK_NAME,
     "adl.core.tasks.process_station_link_batch",
 })
 
@@ -140,16 +140,35 @@ def _queue_depth(connection):
         declared = connection.default_channel.queue_declare(
             queue=INGESTION_QUEUE_NAME, passive=True
         )
-    except ChannelError:
+    except ChannelError as e:
         # On Redis an empty queue has no key, so a passive declare reports
-        # NOT_FOUND — that is a healthy idle queue, not an unobservable one
-        return 0
+        # NOT_FOUND — that is a healthy idle queue, not an unobservable one.
+        # Any other channel error stays unknown: it must not manufacture a
+        # false healthy depth of zero.
+        if _is_not_found(e):
+            return 0
+        logger.warning("[BROKER] Could not read ingestion queue depth: %s", e)
+        return None
     except Exception as e:
         logger.warning("[BROKER] Could not read ingestion queue depth: %s", e)
         return None
     # message_count sums across kombu's priority-suffixed keys, which a raw
     # LLEN on the queue name would undercount
     return declared.message_count
+
+
+def _is_not_found(channel_error):
+    """
+    True when a passive declare failed because the queue does not exist.
+
+    kombu's virtual transports raise with a string ``'404'`` reply code and
+    an amqp broker with an int ``404``; older paths carry only the
+    ``NOT_FOUND`` reply text.
+    """
+    reply_code = getattr(channel_error, "reply_code", None)
+    if reply_code is not None:
+        return str(reply_code) == "404"
+    return "NOT_FOUND" in str(channel_error)
 
 
 def _worker_consuming(inspect):

--- a/adl/src/adl/core/broker.py
+++ b/adl/src/adl/core/broker.py
@@ -1,0 +1,204 @@
+"""
+Layer-2 broker and queue observations for the ingestion diagnostic.
+
+All broker interaction for "is a worker consuming the ingestion queue, and is
+work backing up?" lives behind :func:`get_ingestion_queue_health` — callers
+and tests substitute that one name instead of patching kombu and the Celery
+control API. This is also where the version predicates and ``UNSUPPORTED``
+degradation will live once the dependency pins land.
+
+Two facts the vocabulary here is built on (measured, see issue #151):
+
+- **Depth is not backlog.** BRPOP is destructive: reserved messages leave the
+  Redis list the moment a worker prefetches them, so broker-visible depth
+  undercounts by up to ``prefetch_count + concurrency``. Depth is reported as
+  depth, never as "work outstanding".
+- **``None`` means unknown, not down.** A wedged worker is indistinguishable
+  from a dead one over the control channel, and a broker that does not answer
+  must not manufacture a false outage.
+"""
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+from django.conf import settings
+from kombu import Connection
+from kombu.exceptions import ChannelError
+
+from adl.config.celery import app
+
+logger = logging.getLogger(__name__)
+
+INGESTION_QUEUE_NAME = "adl"
+
+# The task names that constitute ingestion work on the queue — the
+# coordinator and the per-station batch it spawns
+INGESTION_TASK_NAMES = frozenset({
+    "adl.core.tasks.run_network_plugin",
+    "adl.core.tasks.process_station_link_batch",
+})
+
+# One dedicated short-lived connection, bounded at roughly one second per
+# call with no retries: worst case ~2.1 s healthy, ~1.1 s when the broker is
+# unreachable. These must never go into CELERY_BROKER_TRANSPORT_OPTIONS —
+# that would also reconfigure the workers' own blocking BRPOP loop.
+BROKER_CONNECT_TIMEOUT_SECONDS = 1.0
+BROKER_SOCKET_TIMEOUT_SECONDS = 2.0
+INSPECT_TIMEOUT_SECONDS = 1.0
+
+# A running ingestion task is judged against the connection's own interval —
+# a 5-minutely and a daily connection are both judged fairly. Warn once it
+# outlives one tick; call it stuck at three.
+RUNNING_TASK_WARN_INTERVAL_MULTIPLE = 1
+RUNNING_TASK_STUCK_INTERVAL_MULTIPLE = 3
+
+
+@dataclass(frozen=True)
+class RunningIngestionTask:
+    """One ingestion task a worker reported as currently executing."""
+
+    task_id: Optional[str]
+    name: str
+    args: tuple
+    # Wall-clock seconds since the worker started it (``time_start`` is epoch
+    # wall clock, valid across processes). ``None`` when the worker did not
+    # report a start time.
+    age_seconds: Optional[float]
+
+
+@dataclass(frozen=True)
+class IngestionQueueHealth:
+    """
+    A point-in-time observation of the ingestion queue and its workers.
+
+    Each field is independently ``None`` when it could not be observed —
+    unknown, never down. A falsy-but-not-``None`` value is a real
+    observation: depth ``0`` is an empty queue, ``worker_consuming False``
+    is a worker fleet that replied but has nobody on the ingestion queue,
+    and ``running_tasks ()`` is an idle worker that replied.
+    """
+
+    # Broker-visible messages on the ingestion queue. A lower bound on the
+    # work outstanding, since prefetched and executing tasks are not counted.
+    queue_depth: Optional[int]
+    # Is any worker consuming the ingestion queue?
+    worker_consuming: Optional[bool]
+    running_tasks: Optional[Tuple[RunningIngestionTask, ...]]
+
+
+def running_task_warn_after_seconds(network_connection):
+    """Age at which a running ingestion task has outlived its own beat tick."""
+    return RUNNING_TASK_WARN_INTERVAL_MULTIPLE * network_connection.interval * 60
+
+
+def running_task_stuck_after_seconds(network_connection):
+    """Age at which a running ingestion task counts as stuck, not merely slow."""
+    return RUNNING_TASK_STUCK_INTERVAL_MULTIPLE * network_connection.interval * 60
+
+
+def get_ingestion_queue_health():
+    """
+    Observe the ingestion queue over one short-lived, bounded broker
+    connection. Never raises; each signal degrades to ``None`` on its own.
+    """
+    queue_depth = None
+    worker_consuming = None
+    running_tasks = None
+
+    try:
+        with Connection(
+                settings.CELERY_BROKER_URL,
+                connect_timeout=BROKER_CONNECT_TIMEOUT_SECONDS,
+                transport_options={
+                    "socket_connect_timeout": BROKER_CONNECT_TIMEOUT_SECONDS,
+                    "socket_timeout": BROKER_SOCKET_TIMEOUT_SECONDS,
+                    "max_retries": 0,
+                    "retry_on_timeout": False,
+                },
+        ) as connection:
+            queue_depth = _queue_depth(connection)
+
+            inspect = app.control.inspect(
+                timeout=INSPECT_TIMEOUT_SECONDS, connection=connection
+            )
+            worker_consuming = _worker_consuming(inspect)
+            running_tasks = _running_tasks(inspect)
+    except Exception as e:
+        logger.warning("[BROKER] Could not observe the ingestion queue: %s", e)
+
+    return IngestionQueueHealth(
+        queue_depth=queue_depth,
+        worker_consuming=worker_consuming,
+        running_tasks=running_tasks,
+    )
+
+
+def _queue_depth(connection):
+    try:
+        declared = connection.default_channel.queue_declare(
+            queue=INGESTION_QUEUE_NAME, passive=True
+        )
+    except ChannelError:
+        # On Redis an empty queue has no key, so a passive declare reports
+        # NOT_FOUND — that is a healthy idle queue, not an unobservable one
+        return 0
+    except Exception as e:
+        logger.warning("[BROKER] Could not read ingestion queue depth: %s", e)
+        return None
+    # message_count sums across kombu's priority-suffixed keys, which a raw
+    # LLEN on the queue name would undercount
+    return declared.message_count
+
+
+def _worker_consuming(inspect):
+    try:
+        replies = inspect.active_queues()
+    except Exception as e:
+        logger.warning("[BROKER] Could not inspect active queues: %s", e)
+        return None
+
+    # Inspect never returns {} to mean idle — no reply at all collapses to a
+    # falsy value, which is unknown, not "nobody consuming"
+    if not replies:
+        return None
+
+    return any(
+        queue.get("name") == INGESTION_QUEUE_NAME
+        for queues in replies.values()
+        for queue in (queues or [])
+    )
+
+
+def _running_tasks(inspect):
+    try:
+        replies = inspect.active()
+    except Exception as e:
+        logger.warning("[BROKER] Could not inspect active tasks: %s", e)
+        return None
+
+    if not replies:
+        return None
+
+    now = time.time()
+    running = []
+    for worker_tasks in replies.values():
+        for task in worker_tasks or []:
+            if task.get("name") not in INGESTION_TASK_NAMES:
+                continue
+            time_start = task.get("time_start")
+            running.append(RunningIngestionTask(
+                task_id=task.get("id"),
+                name=task["name"],
+                args=_freeze(task.get("args") or []),
+                age_seconds=max(0.0, now - time_start) if time_start is not None else None,
+            ))
+    return tuple(running)
+
+
+def _freeze(value):
+    """Recursively turn lists into tuples so the reported structure is plain and hashable."""
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze(item) for item in value)
+    return value

--- a/adl/src/adl/core/tasks.py
+++ b/adl/src/adl/core/tasks.py
@@ -27,6 +27,9 @@ logger = logging.getLogger(__name__)
 # starved independently of ingestion
 DISPATCH_QUEUE_NAME = "dispatch"
 
+# The queue the ingestion coordinator and its batches run on
+INGESTION_QUEUE_NAME = "adl"
+
 # The registered name of the ingestion coordinator task. Beat schedule entries
 # for a connection are resolved by this plus their args — see
 # find_connection_schedule_entries
@@ -213,7 +216,7 @@ def run_network_plugin(self, network_id):
         )
         task = process_station_link_batch.apply_async(
             args=[network_id, batch_list],
-            queue='adl',
+            queue=INGESTION_QUEUE_NAME,
             soft_time_limit=soft_time_limit,
             time_limit=soft_time_limit + INGEST_TIME_LIMIT_GRACE_SECONDS,
         )
@@ -411,7 +414,7 @@ def create_or_update_network_plugin_periodic_tasks(network_connection):
             'task': sig.name,
             'args': json.dumps([network_connection.id]),
             'enabled': enabled,
-            'queue': 'adl',
+            'queue': INGESTION_QUEUE_NAME,
         }
     )
 

--- a/adl/src/adl/core/tasks.py
+++ b/adl/src/adl/core/tasks.py
@@ -78,10 +78,11 @@ def get_active_dispatch_tasks(timeout=2.0):
     Map of currently executing station dispatches, keyed by
     ``(channel_id, station_link_id)`` with the task's start timestamp as value.
 
-    Returns ``None`` (rather than ``{}``) when no worker replied to the
-    inspect broadcast — callers must treat that as "unknown", not "idle":
-    the dispatch worker may be down, restarting, or too slow to answer
-    within ``timeout``. Never raises.
+    Returns ``None`` when no worker replied to the inspect broadcast —
+    callers must treat that as "unknown", not "idle": the dispatch worker
+    may be down, restarting, or too slow to answer within ``timeout``.
+    (An idle worker replies ``{'worker@host': []}``, never ``{}`` — inspect
+    has no empty-dict reply, so falsy means no reply.) Never raises.
     """
     try:
         active = app.control.inspect(timeout=timeout).active()

--- a/adl/src/adl/core/tests/test_broker_health.py
+++ b/adl/src/adl/core/tests/test_broker_health.py
@@ -1,0 +1,229 @@
+from unittest.mock import MagicMock, patch
+
+from django.test import SimpleTestCase, TestCase
+from kombu.exceptions import ChannelError
+
+from adl.core.broker import (
+    INGESTION_QUEUE_NAME,
+    IngestionQueueHealth,
+    get_ingestion_queue_health,
+    running_task_stuck_after_seconds,
+    running_task_warn_after_seconds,
+)
+from .factories import NetworkConnectionFactory
+
+
+def make_connection_mock(message_count=0, declare_side_effect=None):
+    """A kombu ``Connection`` stand-in whose passive declare is scriptable."""
+    conn = MagicMock()
+    conn.__enter__.return_value = conn
+    conn.__exit__.return_value = False
+    declare = conn.default_channel.queue_declare
+    if declare_side_effect is not None:
+        declare.side_effect = declare_side_effect
+    else:
+        declare.return_value = MagicMock(message_count=message_count)
+    return conn
+
+
+class GetIngestionQueueHealthTests(SimpleTestCase):
+    """
+    All layer-2 broker interaction sits behind this one function; these tests
+    substitute the kombu connection and the inspect API — never a live broker.
+    """
+
+    def call(self, conn, active_queues=None, active=None, inspect_side_effect=None):
+        inspect = MagicMock()
+        if inspect_side_effect is not None:
+            inspect.active_queues.side_effect = inspect_side_effect
+            inspect.active.side_effect = inspect_side_effect
+        else:
+            inspect.active_queues.return_value = active_queues
+            inspect.active.return_value = active
+
+        with patch("adl.core.broker.Connection", return_value=conn), \
+                patch("adl.core.broker.app") as app_mock:
+            app_mock.control.inspect.return_value = inspect
+            return get_ingestion_queue_health()
+
+    def test_healthy_broker_reports_all_three_signals(self):
+        result = self.call(
+            make_connection_mock(message_count=5),
+            active_queues={"adl-worker@host": [{"name": INGESTION_QUEUE_NAME}]},
+            active={
+                "adl-worker@host": [
+                    {
+                        "id": "abc",
+                        "name": "adl.core.tasks.process_station_link_batch",
+                        "args": [1, [2, 3]],
+                        "time_start": 1000.0,
+                    }
+                ]
+            },
+        )
+
+        self.assertIsInstance(result, IngestionQueueHealth)
+        self.assertEqual(result.queue_depth, 5)
+        self.assertTrue(result.worker_consuming)
+        self.assertEqual(len(result.running_tasks), 1)
+
+    def test_empty_queue_reports_depth_zero_not_unknown(self):
+        # On Redis an empty queue has no key, so the passive declare raises
+        # ChannelError — a healthy idle system, not an unobservable one.
+        result = self.call(
+            make_connection_mock(declare_side_effect=ChannelError("NOT_FOUND")),
+            active_queues={"adl-worker@host": [{"name": INGESTION_QUEUE_NAME}]},
+            active={"adl-worker@host": []},
+        )
+
+        self.assertEqual(result.queue_depth, 0)
+
+    def test_depth_unknown_when_declare_fails_unexpectedly(self):
+        result = self.call(
+            make_connection_mock(declare_side_effect=OSError("connection reset")),
+            active_queues={"adl-worker@host": [{"name": INGESTION_QUEUE_NAME}]},
+            active={"adl-worker@host": []},
+        )
+
+        self.assertIsNone(result.queue_depth)
+        # The other signals are independently observable.
+        self.assertTrue(result.worker_consuming)
+        self.assertEqual(result.running_tasks, ())
+
+    def test_no_inspect_reply_is_unknown_not_down(self):
+        result = self.call(
+            make_connection_mock(message_count=2),
+            active_queues=None,
+            active=None,
+        )
+
+        self.assertEqual(result.queue_depth, 2)
+        self.assertIsNone(result.worker_consuming)
+        self.assertIsNone(result.running_tasks)
+
+    def test_worker_replying_but_not_bound_to_ingestion_queue_is_false(self):
+        result = self.call(
+            make_connection_mock(),
+            active_queues={"dispatch-worker@host": [{"name": "dispatch"}]},
+            active={"dispatch-worker@host": []},
+        )
+
+        self.assertIs(result.worker_consuming, False)
+
+    def test_idle_worker_reports_no_running_tasks_not_unknown(self):
+        # Idle is {'worker': []}, never {} — a reply with no tasks means
+        # "nothing running", which is different from no reply at all.
+        result = self.call(
+            make_connection_mock(),
+            active_queues={"adl-worker@host": [{"name": INGESTION_QUEUE_NAME}]},
+            active={"adl-worker@host": []},
+        )
+
+        self.assertEqual(result.running_tasks, ())
+
+    def test_non_ingestion_tasks_are_filtered_out(self):
+        result = self.call(
+            make_connection_mock(),
+            active_queues={"w@host": [{"name": INGESTION_QUEUE_NAME}]},
+            active={
+                "w@host": [
+                    {
+                        "id": "d1",
+                        "name": "adl.core.tasks.dispatch_station",
+                        "args": [1, 2],
+                        "time_start": 1000.0,
+                    },
+                    {
+                        "id": "b1",
+                        "name": "adl.core.tasks.process_station_link_batch",
+                        "args": [1, [2]],
+                        "time_start": 1000.0,
+                    },
+                    {
+                        "id": "c1",
+                        "name": "adl.core.tasks.run_network_plugin",
+                        "args": [1],
+                        "time_start": 1500.0,
+                    },
+                ]
+            },
+        )
+
+        self.assertEqual(
+            sorted(task.task_id for task in result.running_tasks), ["b1", "c1"]
+        )
+
+    def test_running_task_age_is_wall_clock_since_time_start(self):
+        with patch("adl.core.broker.time.time", return_value=1600.0):
+            result = self.call(
+                make_connection_mock(),
+                active_queues={"w@host": [{"name": INGESTION_QUEUE_NAME}]},
+                active={
+                    "w@host": [
+                        {
+                            "id": "b1",
+                            "name": "adl.core.tasks.process_station_link_batch",
+                            "args": [1, [2, 3]],
+                            "time_start": 1000.0,
+                        }
+                    ]
+                },
+            )
+
+        task = result.running_tasks[0]
+        self.assertEqual(task.age_seconds, 600.0)
+        self.assertEqual(task.args, (1, (2, 3)))
+
+    def test_task_without_time_start_has_unknown_age(self):
+        result = self.call(
+            make_connection_mock(),
+            active_queues={"w@host": [{"name": INGESTION_QUEUE_NAME}]},
+            active={
+                "w@host": [
+                    {
+                        "id": "b1",
+                        "name": "adl.core.tasks.process_station_link_batch",
+                        "args": [1, [2]],
+                    }
+                ]
+            },
+        )
+
+        self.assertIsNone(result.running_tasks[0].age_seconds)
+
+    def test_inspect_raising_leaves_inspect_signals_unknown(self):
+        result = self.call(
+            make_connection_mock(message_count=3),
+            inspect_side_effect=OSError("broker gone"),
+        )
+
+        self.assertEqual(result.queue_depth, 3)
+        self.assertIsNone(result.worker_consuming)
+        self.assertIsNone(result.running_tasks)
+
+    def test_unreachable_broker_never_raises_and_reports_all_unknown(self):
+        conn = MagicMock()
+        conn.__enter__.side_effect = OSError("connection refused")
+
+        with patch("adl.core.broker.Connection", return_value=conn), \
+                patch("adl.core.broker.app") as app_mock:
+            app_mock.control.inspect.side_effect = OSError("no broker")
+            result = get_ingestion_queue_health()
+
+        self.assertIsNone(result.queue_depth)
+        self.assertIsNone(result.worker_consuming)
+        self.assertIsNone(result.running_tasks)
+
+
+class RunningTaskThresholdTests(TestCase):
+    """Thresholds derive from the connection's own interval, never fixed seconds."""
+
+    def test_five_minutely_connection(self):
+        connection = NetworkConnectionFactory(plugin_processing_interval=5)
+        self.assertEqual(running_task_warn_after_seconds(connection), 300)
+        self.assertEqual(running_task_stuck_after_seconds(connection), 900)
+
+    def test_daily_connection(self):
+        connection = NetworkConnectionFactory(plugin_processing_interval=1440)
+        self.assertEqual(running_task_warn_after_seconds(connection), 86400)
+        self.assertEqual(running_task_stuck_after_seconds(connection), 259200)

--- a/adl/src/adl/core/tests/test_broker_health.py
+++ b/adl/src/adl/core/tests/test_broker_health.py
@@ -69,14 +69,35 @@ class GetIngestionQueueHealthTests(SimpleTestCase):
 
     def test_empty_queue_reports_depth_zero_not_unknown(self):
         # On Redis an empty queue has no key, so the passive declare raises
-        # ChannelError — a healthy idle system, not an unobservable one.
+        # ChannelError NOT_FOUND — a healthy idle system, not an unobservable
+        # one. Mirrors kombu's virtual-transport raise: reply text and a
+        # string '404' reply code.
+        error = ChannelError(
+            "NOT_FOUND - no queue 'adl' in vhost '/'",
+            (50, 10), "Channel.queue_declare", "404",
+        )
         result = self.call(
-            make_connection_mock(declare_side_effect=ChannelError("NOT_FOUND")),
+            make_connection_mock(declare_side_effect=error),
             active_queues={"adl-worker@host": [{"name": INGESTION_QUEUE_NAME}]},
             active={"adl-worker@host": []},
         )
 
         self.assertEqual(result.queue_depth, 0)
+
+    def test_non_not_found_channel_error_is_unknown_not_empty(self):
+        # Only NOT_FOUND means "no key, so empty". Any other channel error
+        # must not manufacture a false healthy depth of zero.
+        error = ChannelError(
+            "ACCESS_REFUSED - access to queue 'adl' refused",
+            (50, 10), "Channel.queue_declare", 403,
+        )
+        result = self.call(
+            make_connection_mock(declare_side_effect=error),
+            active_queues={"adl-worker@host": [{"name": INGESTION_QUEUE_NAME}]},
+            active={"adl-worker@host": []},
+        )
+
+        self.assertIsNone(result.queue_depth)
 
     def test_depth_unknown_when_declare_fails_unexpectedly(self):
         result = self.call(


### PR DESCRIPTION
Closes #178. Part of the per-connection ingestion diagnostic (#171), decision section 4 (Layer 2 — worker and queue health).

## What

All layer-2 broker interaction sits behind one function, `adl.core.broker.get_ingestion_queue_health()`, returning a plain frozen `IngestionQueueHealth` structure — no broker objects leak to callers. Three calls over one short-lived, bounded connection (1 s connect, 2 s socket, no retries; the bounds deliberately stay off `CELERY_BROKER_TRANSPORT_OPTIONS` so the workers' own BRPOP loop is untouched):

- passive queue declare → broker-visible depth (`message_count`, which sums kombu's priority-suffixed keys where a raw `LLEN` undercounts);
- `inspect().active_queues()` → is any worker consuming the ingestion queue;
- `inspect().active()` → running ingestion tasks with wall-clock ages.

## The two constraints the design turns on

- **Depth is not backlog** — prefetch hides up to `prefetch_count + concurrency` messages, so depth is documented and reported as a lower bound, never as "work outstanding".
- **`None` means unknown, not down** — each signal degrades to `None` independently; the function never raises. An empty Redis queue's `NOT_FOUND` on passive declare reads as depth 0, but any other channel error stays unknown rather than manufacturing a false healthy zero.

Running-task thresholds (`running_task_warn_after_seconds`, `running_task_stuck_after_seconds`) derive from the connection's own interval (1×/3×, per the #151 measurements), so a 5-minutely and a daily connection are judged fairly.

Also: the `'adl'` queue literal is now `tasks.INGESTION_QUEUE_NAME` shared by the enqueue sites and the health probe, and the `get_active_dispatch_tasks` docstring correction from the #151 research (inspect never returns `{}` to mean idle) is applied.

## Tests

14 new tests in `core/tests/test_broker_health.py` — all substitute the kombu connection and inspect API, none touch a live broker, none assert timings. Full suite: 176 passing.