### PR TITLE
feat: layer 6 data freshness — per-station roll-up via the shared status helper

### DIFF
--- a/adl/src/adl/core/tests/factories.py
+++ b/adl/src/adl/core/tests/factories.py
@@ -1,5 +1,6 @@
 import factory
 from django.contrib.gis.geos import Point
+from django.utils import timezone as dj_timezone
 
 from adl.core import models
 
@@ -30,7 +31,10 @@ class StationFactory(factory.django.DjangoModelFactory):
 class UnitFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.Unit
-    
+        # Named units (Celsius, Kelvin) are effectively fixtures — reuse the
+        # row instead of violating the unique name constraint
+        django_get_or_create = ("name",)
+
     name = factory.Sequence(lambda n: f"Unit {n}")
     symbol = factory.Sequence(lambda n: f"U{n}")
 
@@ -85,3 +89,14 @@ class Wis2BoxUploadFactory(factory.django.DjangoModelFactory):
     storage_password = "minio123"
     secure = False
     dataset_id = "urn:wmo:md:test:dataset"
+
+
+class ObservationRecordFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = models.ObservationRecord
+
+    station = factory.SubFactory(StationFactory)
+    connection = factory.SubFactory(NetworkConnectionFactory)
+    parameter = factory.SubFactory(DataParameterFactory)
+    value = 1.0
+    time = factory.LazyFunction(dj_timezone.now)

--- a/adl/src/adl/monitoring/health.py
+++ b/adl/src/adl/monitoring/health.py
@@ -51,6 +51,7 @@ from .constants import (
 from .models import NetworkConnectionHealth, NetworkConnectionHealthTransition
 from .status import (
     ERROR as STATION_DATA_ERROR,
+    WARNING as STATION_DATA_WARNING,
     annotate_station_pull_activity,
     compute_station_status,
     connection_thresholds,
@@ -65,6 +66,15 @@ EVALUATED_LAYERS = (LAYER_SCHEDULER, LAYER_WORKER, LAYER_LOCKS, LAYER_DATA)
 
 
 @dataclass(frozen=True)
+class CheckLink:
+    """A link rendered after a check's message (e.g. the data layer links
+    through to the per-station monitoring page)."""
+
+    url: str
+    label: str
+
+
+@dataclass(frozen=True)
 class HealthCheck:
     """One row of the checklist. ``layer`` is ``None`` for the precondition band."""
 
@@ -75,10 +85,7 @@ class HealthCheck:
     message: str
     # Advisory checks are shown but never seize the headline
     blocking: bool = True
-    # Optional link rendered after the message (e.g. the data layer links
-    # through to the affected stations)
-    link_url: Optional[str] = None
-    link_label: Optional[str] = None
+    link: Optional[CheckLink] = None
 
     @property
     def coloured(self):
@@ -237,11 +244,14 @@ class _ChecklistBuilder:
                               "check meaningless."),
                 )
             else:
-                state, message, blocking, *rest = getattr(self, f"_check_{check_id}")()
-                extra = rest[0] if rest else {}
+                # A check returns (state, message, blocking) with an optional
+                # trailing CheckLink
+                result = getattr(self, f"_check_{check_id}")()
+                state, message, blocking = result[:3]
+                link = result[3] if len(result) > 3 else None
                 check = HealthCheck(id=check_id, layer=layer, label=label,
                                     state=state, message=message, blocking=blocking,
-                                    **extra)
+                                    link=link)
                 if check.blocking and check.state == CheckState.FAILED:
                     self.failed = True
             checks.append(check)
@@ -469,6 +479,7 @@ class _ChecklistBuilder:
 
         total = 0
         stale = 0
+        aging = 0
         for link in links:
             total += 1
             status = compute_station_status(
@@ -480,34 +491,42 @@ class _ChecklistBuilder:
             )
             if status.data_status == STATION_DATA_ERROR:
                 stale += 1
+            elif status.data_status == STATION_DATA_WARNING:
+                aging += 1
 
         if not total:
             return (CheckState.OK,
                     _("This connection has no enabled station links."),
                     True)
 
-        extra = {
-            "link_url": reverse("network_connection_monitoring",
-                                args=(self.connection.id,)),
-            "link_label": _("View stations"),
-        }
-        counts = {"stale": stale, "total": total}
+        link = CheckLink(
+            url=reverse("network_connection_monitoring", args=(self.connection.id,)),
+            label=_("View stations"),
+        )
+        counts = {"stale": stale, "aging": aging, "total": total}
         if not stale:
-            return (CheckState.OK,
-                    _("Data is current on all %(total)d enabled station(s), "
-                      "within the connection's freshness limits.") % counts,
-                    True, extra)
+            # The verdict rolls up stale stations only, but the message must
+            # not claim more than the shared helper reports — aging stations
+            # render amber on the monitoring panel and are named here too
+            if aging:
+                message = _("No station has stale data, but %(aging)d of "
+                            "%(total)d enabled station(s) have no fresh "
+                            "observations within the warning window.") % counts
+            else:
+                message = _("Data is current on all %(total)d enabled "
+                            "station(s).") % counts
+            return CheckState.OK, message, True, link
         if stale == total:
             return (CheckState.FAILED,
                     _("All %(total)d enabled station(s) have stale data — no "
                       "recent observations within the connection's freshness "
                       "limit.") % counts,
-                    True, extra)
+                    True, link)
         return (CheckState.WARNING,
                 _("%(stale)d of %(total)d enabled stations have stale data — "
                   "no recent observations within the connection's freshness "
                   "limit.") % counts,
-                True, extra)
+                True, link)
 
 
 def store_connection_health(connection, checklist, now=None):

--- a/adl/src/adl/monitoring/health.py
+++ b/adl/src/adl/monitoring/health.py
@@ -5,7 +5,8 @@ holds. Core records what happened (heartbeat, schedule, locks, activity
 logs); this module decides what it means.
 
 :func:`evaluate_connection_health` returns the full checklist for the
-precondition band and the internal layers 1-3 (scheduler, worker, locks).
+precondition band and the internal layers: 1-3 (scheduler, worker, locks)
+and 6 (data freshness, rolled up per station).
 :func:`store_connection_health` persists only change — one overwritten
 headline row per connection plus an append-only transitions log.
 
@@ -23,6 +24,7 @@ from dataclasses import dataclass
 from typing import Optional, Tuple
 
 from django.core.cache import cache
+from django.urls import reverse
 from django.utils import timezone as dj_timezone
 from django.utils.translation import gettext as _
 from django_celery_beat.models import IntervalSchedule
@@ -40,19 +42,26 @@ from adl.core.models import (
 from adl.core.tasks import find_connection_schedule_entries, ingest_station_lock_key
 
 from .constants import (
+    LAYER_DATA,
     LAYER_LOCKS,
     LAYER_SCHEDULER,
     LAYER_WORKER,
     CheckState,
 )
 from .models import NetworkConnectionHealth, NetworkConnectionHealthTransition
+from .status import (
+    ERROR as STATION_DATA_ERROR,
+    annotate_station_pull_activity,
+    compute_station_status,
+    connection_thresholds,
+)
 
 logger = logging.getLogger(__name__)
 
-# The ladder this ticket evaluates. Layers 4-6 (network, source, data) join
-# as their evidence sources land; appending here must not renumber anything,
-# which is why layers are identifiers and never ordinals.
-EVALUATED_LAYERS = (LAYER_SCHEDULER, LAYER_WORKER, LAYER_LOCKS)
+# The evaluated ladder. Layers 4-5 (network, source) join as their evidence
+# sources land; inserting there must not renumber anything, which is why
+# layers are identifiers and never ordinals.
+EVALUATED_LAYERS = (LAYER_SCHEDULER, LAYER_WORKER, LAYER_LOCKS, LAYER_DATA)
 
 
 @dataclass(frozen=True)
@@ -66,6 +75,10 @@ class HealthCheck:
     message: str
     # Advisory checks are shown but never seize the headline
     blocking: bool = True
+    # Optional link rendered after the message (e.g. the data layer links
+    # through to the affected stations)
+    link_url: Optional[str] = None
+    link_label: Optional[str] = None
 
     @property
     def coloured(self):
@@ -178,6 +191,7 @@ def _ladder_plan():
         ("running_tasks", LAYER_WORKER, _("Running ingestion tasks")),
         ("tick_consumed", LAYER_WORKER, _("Tick reached a worker")),
         ("station_locks", LAYER_LOCKS, _("Station locks")),
+        ("data_freshness", LAYER_DATA, _("Data freshness")),
     )
 
 
@@ -223,9 +237,11 @@ class _ChecklistBuilder:
                               "check meaningless."),
                 )
             else:
-                state, message, blocking = getattr(self, f"_check_{check_id}")()
+                state, message, blocking, *rest = getattr(self, f"_check_{check_id}")()
+                extra = rest[0] if rest else {}
                 check = HealthCheck(id=check_id, layer=layer, label=label,
-                                    state=state, message=message, blocking=blocking)
+                                    state=state, message=message, blocking=blocking,
+                                    **extra)
                 if check.blocking and check.state == CheckState.FAILED:
                     self.failed = True
             checks.append(check)
@@ -439,6 +455,59 @@ class _ChecklistBuilder:
                   "no task behind them — a worker died mid-run. They expire on "
                   "their own TTL.") % counts,
                 True)
+
+    # -- Layer 6: data freshness, rolled up per station from the shared
+    # status helper. All stations affected -> FAILED, some -> WARNING,
+    # none -> OK — one misconfigured station cannot turn a healthy
+    # connection red.
+
+    def _check_data_freshness(self):
+        links = annotate_station_pull_activity(
+            self.connection.station_links.filter(enabled=True)
+        )
+        thresholds = connection_thresholds(self.connection)
+
+        total = 0
+        stale = 0
+        for link in links:
+            total += 1
+            status = compute_station_status(
+                last_check=link.last_check,
+                last_check_success=link.last_log_success,
+                last_data_time=link.last_collected,
+                thresholds=thresholds,
+                now=self.now,
+            )
+            if status.data_status == STATION_DATA_ERROR:
+                stale += 1
+
+        if not total:
+            return (CheckState.OK,
+                    _("This connection has no enabled station links."),
+                    True)
+
+        extra = {
+            "link_url": reverse("network_connection_monitoring",
+                                args=(self.connection.id,)),
+            "link_label": _("View stations"),
+        }
+        counts = {"stale": stale, "total": total}
+        if not stale:
+            return (CheckState.OK,
+                    _("Data is current on all %(total)d enabled station(s), "
+                      "within the connection's freshness limits.") % counts,
+                    True, extra)
+        if stale == total:
+            return (CheckState.FAILED,
+                    _("All %(total)d enabled station(s) have stale data — no "
+                      "recent observations within the connection's freshness "
+                      "limit.") % counts,
+                    True, extra)
+        return (CheckState.WARNING,
+                _("%(stale)d of %(total)d enabled stations have stale data — "
+                  "no recent observations within the connection's freshness "
+                  "limit.") % counts,
+                True, extra)
 
 
 def store_connection_health(connection, checklist, now=None):

--- a/adl/src/adl/monitoring/status.py
+++ b/adl/src/adl/monitoring/status.py
@@ -13,11 +13,44 @@ request — so it is callable from tasks, management commands and templates.
 from dataclasses import dataclass
 from datetime import timedelta
 
+from django.db.models import OuterRef, Subquery
 from django.utils import timezone as dj_timezone
 
 ACTIVE = "active"
 WARNING = "warning"
 ERROR = "error"
+
+
+def annotate_station_pull_activity(station_links):
+    """Annotate a StationLink queryset with the three timestamps
+    :func:`compute_station_status` consumes on the pull side: ``last_check``
+    and ``last_log_success`` from the latest pull activity log, and
+    ``last_collected`` from the latest stored observation.
+
+    The activity view and the connection diagnostic both read from here, so
+    they cannot disagree about the same station.
+    """
+    from adl.core.models import ObservationRecord
+
+    from .models import StationLinkActivityLog
+
+    latest_log_sq = StationLinkActivityLog.objects.filter(
+        station_link=OuterRef('pk'),
+        direction='pull'
+    ).order_by('-time')
+
+    # Filtering by connection utilises the composite index on
+    # ObservationRecord ['connection', 'station', '-time']
+    latest_obs_sq = ObservationRecord.objects.filter(
+        station=OuterRef('station'),
+        connection=OuterRef('network_connection')
+    ).order_by('-time')
+
+    return station_links.annotate(
+        last_check=Subquery(latest_log_sq.values('time')[:1]),
+        last_log_success=Subquery(latest_log_sq.values('success')[:1]),
+        last_collected=Subquery(latest_obs_sq.values('time')[:1])
+    )
 
 
 @dataclass(frozen=True)

--- a/adl/src/adl/monitoring/status.py
+++ b/adl/src/adl/monitoring/status.py
@@ -6,8 +6,10 @@ is the one computation both consume — and the seam anything else that needs
 the same verdict (the per-connection diagnostic) should read from, so they
 cannot disagree about the same station.
 
-Everything here works on plain domain objects and timestamps — no view, no
-request — so it is callable from tasks, management commands and templates.
+Nothing here touches a view or a request, so it is callable from tasks,
+management commands and templates. The status computation itself works on
+plain timestamps; :func:`annotate_station_pull_activity` is the one queryset
+helper, supplying those timestamps the same way to every consumer.
 """
 
 from dataclasses import dataclass

--- a/adl/src/adl/monitoring/templates/monitoring/partials/health_check_table.html
+++ b/adl/src/adl/monitoring/templates/monitoring/partials/health_check_table.html
@@ -13,7 +13,12 @@ render grey via --muted and are distinguished by wording.
                     {{ check.state }}
                 </span>
             </td>
-            <td>{{ check.message }}</td>
+            <td>
+                {{ check.message }}
+                {% if check.link_url %}
+                    <a href="{{ check.link_url }}">{{ check.link_label }}</a>
+                {% endif %}
+            </td>
         </tr>
     {% endfor %}
     </tbody>

--- a/adl/src/adl/monitoring/templates/monitoring/partials/health_check_table.html
+++ b/adl/src/adl/monitoring/templates/monitoring/partials/health_check_table.html
@@ -15,8 +15,8 @@ render grey via --muted and are distinguished by wording.
             </td>
             <td>
                 {{ check.message }}
-                {% if check.link_url %}
-                    <a href="{{ check.link_url }}">{{ check.link_label }}</a>
+                {% if check.link %}
+                    <a href="{{ check.link.url }}">{{ check.link.label }}</a>
                 {% endif %}
             </td>
         </tr>

--- a/adl/src/adl/monitoring/tests/test_health.py
+++ b/adl/src/adl/monitoring/tests/test_health.py
@@ -462,7 +462,7 @@ class DataLayerTests(HealthEvaluatorTestCase):
 
         check = self.check(checklist, "data_freshness")
         self.assertIn("1 of 2", check.message)
-        self.assertTrue(check.link_url)
+        self.assertIsNotNone(check.link)
 
     def test_headline_anchors_to_data_when_layers_one_to_three_are_green(self):
         self.make_healthy()
@@ -493,6 +493,38 @@ class DataLayerTests(HealthEvaluatorTestCase):
         checklist = self.evaluate()
 
         self.assertEqual(checklist.status, CheckState.OK)
+
+    def test_data_just_inside_the_error_limit_is_not_stale(self):
+        # Error limit is 12x the 15-minute interval = 180 minutes
+        self.make_healthy()
+        self.observe(self.link, timedelta(minutes=170))
+
+        checklist = self.evaluate()
+
+        self.assertEqual(checklist.status, CheckState.OK)
+        self.assertEqual(self.check(checklist, "data_freshness").state, CheckState.OK)
+
+    def test_data_just_past_the_error_limit_is_stale(self):
+        self.make_healthy()
+        self.observe(self.link, timedelta(minutes=190))
+
+        checklist = self.evaluate()
+
+        self.assertEqual(checklist.status, CheckState.FAILED)
+        self.assertEqual(checklist.first_failing_layer, LAYER_DATA)
+
+    def test_aging_stations_are_named_in_an_ok_message(self):
+        # An amber station on the monitoring panel must not read as
+        # "data is current" here — the two surfaces cannot disagree
+        self.make_healthy()
+        self.observe(self.link, timedelta(minutes=100))  # past warning, before error
+
+        checklist = self.evaluate()
+
+        check = self.check(checklist, "data_freshness")
+        self.assertEqual(check.state, CheckState.OK)
+        self.assertIn("1 of 1", check.message)
+        self.assertNotIn("current", check.message)
 
     def test_data_check_is_skipped_below_an_upper_failure(self):
         # No schedule entry: the scheduler fails first

--- a/adl/src/adl/monitoring/tests/test_health.py
+++ b/adl/src/adl/monitoring/tests/test_health.py
@@ -17,8 +17,13 @@ from django_celery_beat.models import IntervalSchedule, PeriodicTask
 from adl.core.broker import IngestionQueueHealth, RunningIngestionTask
 from adl.core.models import NetworkConnectionHeartbeat
 from adl.core.tasks import INGESTION_TASK_NAME, ingest_station_lock_key
-from adl.core.tests.factories import NetworkConnectionFactory, StationLinkFactory
+from adl.core.tests.factories import (
+    NetworkConnectionFactory,
+    ObservationRecordFactory,
+    StationLinkFactory,
+)
 from adl.monitoring.constants import (
+    LAYER_DATA,
     LAYER_LOCKS,
     LAYER_SCHEDULER,
     LAYER_WORKER,
@@ -401,3 +406,99 @@ class StoredVerdictTests(HealthEvaluatorTestCase):
         self.assertEqual(health.headline_check_id, "schedule_entry")
         self.assertEqual(health.since, first)
         self.assertEqual(NetworkConnectionHealthTransition.objects.count(), 1)
+
+
+class DataLayerTests(HealthEvaluatorTestCase):
+    """Layer 6 rolls up per-station data freshness: all stations affected
+    FAILED, some WARNING, none OK — driven by the shared per-station
+    status helper, never a second implementation."""
+
+    def observe(self, station_link, age):
+        return ObservationRecordFactory(
+            station=station_link.station,
+            connection=self.connection,
+            time=dj_tz.now() - age,
+        )
+
+    def test_fresh_data_on_every_station_reports_ok(self):
+        self.make_healthy()
+        self.observe(self.link, timedelta(minutes=10))
+
+        checklist = self.evaluate()
+
+        self.assertEqual(checklist.status, CheckState.OK)
+        self.assertEqual(self.check(checklist, "data_freshness").state, CheckState.OK)
+
+    def test_stale_data_on_all_stations_fails_the_data_layer(self):
+        self.make_healthy()
+        # Well past the error limit of 12x the 15-minute interval
+        self.observe(self.link, timedelta(hours=6))
+
+        checklist = self.evaluate()
+
+        self.assertEqual(checklist.status, CheckState.FAILED)
+        self.assertEqual(checklist.first_failing_layer, LAYER_DATA)
+        self.assertEqual(checklist.headline_check_id, "data_freshness")
+
+    def test_one_stale_station_of_two_warns_not_fails(self):
+        fresh_link = StationLinkFactory(network_connection=self.connection)
+        self.make_healthy()
+        self.observe(self.link, timedelta(hours=6))
+        self.observe(fresh_link, timedelta(minutes=10))
+
+        checklist = self.evaluate()
+
+        self.assertEqual(checklist.status, CheckState.WARNING)
+        self.assertEqual(checklist.first_failing_layer, LAYER_DATA)
+        check = self.check(checklist, "data_freshness")
+        self.assertEqual(check.state, CheckState.WARNING)
+
+    def test_rendered_content_is_the_counts_with_a_station_link(self):
+        StationLinkFactory(network_connection=self.connection)
+        self.make_healthy()
+        self.observe(self.link, timedelta(hours=6))
+
+        checklist = self.evaluate()
+
+        check = self.check(checklist, "data_freshness")
+        self.assertIn("1 of 2", check.message)
+        self.assertTrue(check.link_url)
+
+    def test_headline_anchors_to_data_when_layers_one_to_three_are_green(self):
+        self.make_healthy()
+        self.observe(self.link, timedelta(hours=6))
+
+        checklist = self.evaluate()
+
+        for check in checklist.checks:
+            if check.layer != LAYER_DATA:
+                self.assertNotEqual(check.state, CheckState.FAILED, check.id)
+        self.assertEqual(checklist.first_failing_layer, LAYER_DATA)
+
+    def test_station_that_never_produced_data_is_not_reported_stale(self):
+        # The day-one state on every deployment: no observations at all
+        self.make_healthy()
+
+        checklist = self.evaluate()
+
+        self.assertEqual(checklist.status, CheckState.OK)
+        self.assertEqual(self.check(checklist, "data_freshness").state, CheckState.OK)
+
+    def test_disabled_station_links_are_excluded_from_the_roll_up(self):
+        stale_link = StationLinkFactory(network_connection=self.connection, enabled=False)
+        self.make_healthy()
+        self.observe(self.link, timedelta(minutes=10))
+        self.observe(stale_link, timedelta(hours=6))
+
+        checklist = self.evaluate()
+
+        self.assertEqual(checklist.status, CheckState.OK)
+
+    def test_data_check_is_skipped_below_an_upper_failure(self):
+        # No schedule entry: the scheduler fails first
+        self.observe(self.link, timedelta(hours=6))
+
+        checklist = self.evaluate()
+
+        self.assertEqual(checklist.first_failing_layer, LAYER_SCHEDULER)
+        self.assertEqual(self.check(checklist, "data_freshness").state, CheckState.SKIPPED)

--- a/adl/src/adl/monitoring/views/activity.py
+++ b/adl/src/adl/monitoring/views/activity.py
@@ -8,12 +8,12 @@ from rest_framework.views import APIView
 
 from adl.core.models import (
     NetworkConnection,
-    ObservationRecord,
     DispatchChannel,
     StationChannelDispatchStatus
 )
 from adl.monitoring.models import StationLinkActivityLog
 from adl.monitoring.status import (
+    annotate_station_pull_activity,
     compute_station_status,
     connection_thresholds,
     dispatch_channel_thresholds,
@@ -25,29 +25,10 @@ class NetworkConnectionActivityView(APIView):
         # 1. Fetch the Connection
         connection = get_object_or_404(NetworkConnection, id=connection_id)
         
-        # --- PREPARE QUERIES ---
-        
-        # Subquery 1: Latest Activity Log (Pipeline Status)
-        # Uses Index: ['station_link', '-time']
-        latest_log_sq = StationLinkActivityLog.objects.filter(
-            station_link=OuterRef('pk'),
-            direction='pull'  # Explicitly looking for PULL activities
-        ).order_by('-time')
-        
-        # Subquery 2: Latest Observation (Data Status)
-        # Uses Index: ['connection', 'station', '-time']
-        # We must filter by 'connection' to utilize the composite index effectively
-        latest_obs_sq = ObservationRecord.objects.filter(
-            station=OuterRef('station'),
-            connection=connection
-        ).order_by('-time')
-        
-        # Main Query: Fetch StationLinks and annotate with latest timestamps/status
-        # This executes ONE main SQL query instead of N+1
-        station_links = connection.station_links.select_related("station").annotate(
-            last_check=Subquery(latest_log_sq.values('time')[:1]),
-            last_log_success=Subquery(latest_log_sq.values('success')[:1]),
-            last_collected=Subquery(latest_obs_sq.values('time')[:1])
+        # Main Query: Fetch StationLinks annotated with the latest
+        # timestamps via the shared helper — ONE main SQL query, no N+1
+        station_links = annotate_station_pull_activity(
+            connection.station_links.select_related("station")
         )
         
         # --- SETUP THRESHOLDS ---


### PR DESCRIPTION
Closes #180. Part of the ingestion diagnostic (spec #171).

## What

Adds the data layer — the bottom of the diagnostic ladder — to the per-connection ingestion diagnostic.

- A `data_freshness` check on a new `data` layer group, asking whether observations are arriving and recent per station.
- Roll-up per station: **all stale → FAILED, some → WARNING, none → OK**, with the counts as the rendered content and a "View stations" link through to the connection's monitoring page. One stale station out of many yields WARNING, so a single broken station cannot turn a healthy connection red.
- With layers 1–3 green and layer 6 red, the headline anchors down to layer 6 (layers 4–5 are unobserved and not guessed at).

## How

- The per-station subquery annotation the activity view used inline is extracted into `status.annotate_station_pull_activity`; both the activity view and the evaluator now consume it plus the existing `compute_station_status` — the diagnostic page and the dashboard panel cannot disagree about the same station.
- Checks may return an optional typed `CheckLink`, rendered after the message in the shared check-table partial.
- Stations in the helper's warning band (aging, or never any data) do not move the verdict — the roll-up counts stale stations only, per the acceptance criteria — but the OK message names them so the page never claims "data is current" while the dashboard shows amber.
- Incidental: `UnitFactory` gains `django_get_or_create` on `name` — creating two observation records tripped the unique unit-name constraint — and a new `ObservationRecordFactory`.

## Tests

Seam-1 tests in `test_health.py` from ordinary domain rows: roll-up boundaries (including just-inside/just-past the 12×-interval error limit), headline anchoring, disabled-link exclusion, SKIPPED below an upper failure, and the day-one no-data state. Full suite: 223 tests, green.