### PR TITLE
feat: read-time classification feeds layers 4-5; sources count qualifies layer 5

### DIFF
--- a/adl/src/adl/monitoring/classification.py
+++ b/adl/src/adl/monitoring/classification.py
@@ -1,0 +1,126 @@
+"""
+Read-time failure classification — the untrusted fallback tier.
+
+The trusted tier stamps activity logs at write time from the exception
+*type* (:mod:`adl.core.classification`). This module runs only over rows
+that tier did not stamp: ordered, first-match text rules with binary
+confidence, recomputed on every read and never written back — so improving
+the rule table retroactively corrects every historical row with no data
+migration.
+
+Two constraints keep the fallback honest:
+
+- **The layer belongs to the rule, not the category.** Where a plugin
+  collapses a connect timeout and a read timeout into one string, the text
+  rule claims the category but declines the layer (``None``) — a rule with
+  no layer creates no layer-4/5 evidence and stays layer-6 detail.
+- **Ambiguity declines.** A message no rule matches yields no
+  classification rather than a guess, so the headline never confidently
+  names the wrong layer.
+
+Every outcome carries the rule's **normalised** text, never the raw
+message — raw exception text can embed credentials and belongs to the
+activity log row, not to a headline.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+from django.utils.translation import gettext_lazy as _
+
+# Normalised, credential-free wording for each category in the closed
+# vocabulary — what an evidence slot renders in place of raw exception text
+CATEGORY_MESSAGES = {
+    "DNS_FAILURE": _("The source host name did not resolve (DNS failure)."),
+    "TCP_REFUSED": _("The source host refused a TCP connection."),
+    "TCP_TIMEOUT": _("A connection to the source timed out."),
+    "TLS_FAILURE": _("TLS negotiation with the source failed."),
+    "AUTH_FAILED": _("The source rejected the configured credentials."),
+    "PERMISSION_DENIED": _("The source denied permission for the requested "
+                           "operation."),
+    "PATH_NOT_FOUND": _("The configured remote path was not found on the "
+                        "source."),
+    "PROTOCOL_ERROR": _("The source replied with an unexpected protocol "
+                        "response."),
+    "UNKNOWN": _("The run failed with an unclassified connection error."),
+}
+
+
+def category_message(category):
+    """The normalised text for a category — used for write-time-stamped
+    rows too, so no tier ever surfaces raw message text on a slot."""
+    return CATEGORY_MESSAGES[category]
+
+
+@dataclass(frozen=True)
+class ReadTimeRule:
+    """One ordered rule: a lowercase needle searched in the raw message.
+    ``layer`` is 4 (network path), 5 (source), or ``None`` when the text
+    alone cannot place the failure."""
+
+    needle: str
+    category: str
+    layer: Optional[int]
+
+
+# Ordered, first-match. Specific needles come before generic ones — a
+# message naming both an auth failure and a timeout is claimed by the auth
+# rule. These target exception literals owned by sibling repositories and
+# the standard library; a reworded upstream message silently stops matching,
+# which is exactly why this tier is the fallback and the type-keyed
+# write-time tier is the contract.
+READ_TIME_RULES = (
+    # -- Source (layer 5): the host answered; what it said is the evidence
+    ReadTimeRule("login incorrect", "AUTH_FAILED", 5),
+    ReadTimeRule("login authentication failed", "AUTH_FAILED", 5),
+    ReadTimeRule("authentication failed", "AUTH_FAILED", 5),
+    ReadTimeRule("530 login", "AUTH_FAILED", 5),
+    ReadTimeRule("password is incorrect", "AUTH_FAILED", 5),
+    ReadTimeRule("no such file or directory", "PATH_NOT_FOUND", 5),
+    ReadTimeRule("permission denied", "PERMISSION_DENIED", 5),
+    # -- Network path (layer 4): the host was never reached
+    ReadTimeRule("name or service not known", "DNS_FAILURE", 4),
+    ReadTimeRule("nodename nor servname provided", "DNS_FAILURE", 4),
+    ReadTimeRule("temporary failure in name resolution", "DNS_FAILURE", 4),
+    ReadTimeRule("getaddrinfo failed", "DNS_FAILURE", 4),
+    ReadTimeRule("connection refused", "TCP_REFUSED", 4),
+    # -- Layer declined: the text alone cannot place these
+    # "timed out" covers both a connect timeout (layer 4) and a read
+    # timeout (layer 5); "certificate verify failed" both handshake and
+    # mid-read TLS faults. The category is claimed, the layer is not.
+    ReadTimeRule("certificate verify failed", "TLS_FAILURE", None),
+    ReadTimeRule("ssl handshake", "TLS_FAILURE", None),
+    ReadTimeRule("timed out", "TCP_TIMEOUT", None),
+)
+
+
+@dataclass(frozen=True)
+class ReadTimeClassification:
+    """The outcome of one matched rule. ``message`` is the rule's
+    normalised text — never the raw message it matched."""
+
+    category: str
+    layer: Optional[int]
+    message: str
+
+
+def classify_failure_text(text) -> Optional[ReadTimeClassification]:
+    """
+    Classify a raw failure message by the ordered rule table.
+
+    Returns ``None`` when no rule matches — a genuinely ambiguous error is
+    left unclassified rather than guessed. Callers must apply this only to
+    rows with no write-time ``error_category``; a write-time stamp is the
+    trusted tier and is never second-guessed here.
+    """
+    if not text:
+        return None
+    haystack = text.lower()
+    for rule in READ_TIME_RULES:
+        if rule.needle in haystack:
+            return ReadTimeClassification(
+                category=rule.category,
+                layer=rule.layer,
+                message=category_message(rule.category),
+            )
+    return None

--- a/adl/src/adl/monitoring/constants.py
+++ b/adl/src/adl/monitoring/constants.py
@@ -49,6 +49,20 @@ PROBE_LAYER_IDS = {
     5: LAYER_SOURCE,
 }
 
+# Provenance of the single evidence slot each external layer holds: who
+# produced the winning observation. INTERNAL is core's own trusted record
+# (a scheduled run, or a write-time-stamped failure); LOG_CLASSIFICATION is
+# the read-time text-rule fallback over unstamped rows.
+PROVENANCE_INTERNAL = "INTERNAL"
+PROVENANCE_PROBE = "PROBE"
+PROVENANCE_LOG_CLASSIFICATION = "LOG_CLASSIFICATION"
+
+PROVENANCE_LABELS = {
+    PROVENANCE_INTERNAL: _("scheduled-run evidence"),
+    PROVENANCE_PROBE: _("on-demand probe"),
+    PROVENANCE_LOG_CLASSIFICATION: _("classified from the run log"),
+}
+
 LAYER_LABELS = {
     LAYER_SCHEDULER: _("Scheduler"),
     LAYER_WORKER: _("Worker & queue"),

--- a/adl/src/adl/monitoring/health.py
+++ b/adl/src/adl/monitoring/health.py
@@ -21,9 +21,12 @@ Two rules govern the checklist shape:
 
 import logging
 from dataclasses import dataclass
+from datetime import datetime, timedelta
 from typing import Optional, Tuple
 
 from django.core.cache import cache
+from django.core.exceptions import ValidationError
+from django.db.models import Count, Max, Q
 from django.urls import reverse
 from django.utils import timezone as dj_timezone
 from django.utils.translation import gettext as _
@@ -48,6 +51,7 @@ from adl.core.source_checks import (
 )
 from adl.core.tasks import find_connection_schedule_entries, ingest_station_lock_key
 
+from .classification import category_message, classify_failure_text
 from .constants import (
     LAYER_DATA,
     LAYER_LOCKS,
@@ -55,12 +59,17 @@ from .constants import (
     LAYER_SCHEDULER,
     LAYER_SOURCE,
     LAYER_WORKER,
+    PROVENANCE_INTERNAL,
+    PROVENANCE_LABELS,
+    PROVENANCE_LOG_CLASSIFICATION,
+    PROVENANCE_PROBE,
     CheckState,
 )
 from .models import (
     NetworkConnectionHealth,
     NetworkConnectionHealthTransition,
     SourceProbeResult,
+    StationLinkActivityLog,
 )
 from .status import (
     ERROR as STATION_DATA_ERROR,
@@ -86,6 +95,57 @@ EVALUATED_LAYERS = (LAYER_SCHEDULER, LAYER_WORKER, LAYER_LOCKS,
 # cooldown: freshness asks "can I still trust this", cooldown asks "may I
 # ask again yet".
 PROBE_FRESHNESS_SECONDS = 15 * 60
+
+# Evidence read from activity logs is fresh within 2x the connection's own
+# interval — reusing the heartbeat's overdue margin rather than the
+# probe-shaped 15 minutes, so a daily and a 5-minutely connection are both
+# judged fairly
+LOG_EVIDENCE_INTERVAL_MULTIPLIER = 2
+
+# The terminal activity states that constitute evidence. SKIPPED is
+# deliberately absent: a lock collision merely looks like a run, and
+# counting it would manufacture fake layer-4 OK evidence exactly when the
+# system is busiest.
+_TERMINAL_LOG_STATUSES = (
+    StationLinkActivityLog.ActivityStatus.COMPLETED,
+    StationLinkActivityLog.ActivityStatus.FAILED,
+)
+
+
+@dataclass(frozen=True)
+class Evidence:
+    """One observation feeding an external layer's evidence slot.
+
+    ``message`` is always normalised text (a probe step's own message, a
+    classification rule's wording, or core's run summary) — never a raw
+    exception message, which can embed credentials.
+    """
+
+    provenance: str  # PROVENANCE_INTERNAL / PROVENANCE_PROBE / PROVENANCE_LOG_CLASSIFICATION
+    state: str       # CheckState.OK or CheckState.FAILED
+    message: str
+    at: datetime
+
+
+def station_link_drifted(station_link) -> bool:
+    """
+    Whether a stored station link no longer passes its own validation
+    rules — ``full_clean()`` and nothing more, so every rule a plugin adds
+    to ``clean()`` improves this check retroactively.
+
+    Only ``ValidationError`` means drift: a crash in a validator is not
+    evidence the configuration is wrong, and unhandled it would blind the
+    diagnostic from one bad plugin.
+    """
+    try:
+        station_link.full_clean(validate_unique=False)
+    except ValidationError:
+        return True
+    except Exception:
+        logger.exception("[HEALTH] full_clean crashed for station link %s",
+                         station_link.id)
+        return False
+    return False
 
 
 def probe_age_minutes(now, at):
@@ -115,6 +175,11 @@ class HealthCheck:
     # Advisory checks are shown but never seize the headline
     blocking: bool = True
     link: Optional[CheckLink] = None
+    # External layers only: who produced the winning observation, the
+    # superseded observation it displaced, and that loser's rendered line
+    provenance: Optional[str] = None
+    superseded: Optional[Evidence] = None
+    superseded_message: Optional[str] = None
 
     @property
     def coloured(self):
@@ -227,9 +292,10 @@ def _ladder_plan():
         ("running_tasks", LAYER_WORKER, _("Running ingestion tasks")),
         ("tick_consumed", LAYER_WORKER, _("Tick reached a worker")),
         ("station_locks", LAYER_LOCKS, _("Station locks")),
-        (CHECK_DNS, LAYER_NETWORK, _("Source host resolves (DNS)")),
-        (CHECK_TCP, LAYER_NETWORK, _("TCP connection to the source")),
-        (CHECK_SOURCE, LAYER_SOURCE, _("Source accepts credentials and offers data")),
+        # One evidence slot per external layer: probe steps stay stored at
+        # DNS/TCP granularity, but the layer holds a single verdict
+        ("network_path", LAYER_NETWORK, _("Network path to the source")),
+        ("source_check", LAYER_SOURCE, _("Source accepts credentials and offers data")),
         ("data_freshness", LAYER_DATA, _("Data freshness")),
     )
 
@@ -258,6 +324,8 @@ class _ChecklistBuilder:
         self.now = now
         self.failed = False
         self._source_endpoint = _UNRESOLVED
+        self._drifted_ids = None
+        self._data = None
         self.schedule_entries = find_connection_schedule_entries(connection)
 
     @property
@@ -269,7 +337,13 @@ class _ChecklistBuilder:
     def run(self):
         checks = []
         for check_id, layer, label in _ladder_plan():
-            if self.failed:
+            # A failure above makes a check meaningless — with one honest
+            # exception: when the source layer consulted data freshness (for
+            # the sources-count qualification), the data verdict was
+            # genuinely observed and reporting it as SKIPPED would hide the
+            # very evidence that triggered the layer-5 verdict
+            observed_anyway = check_id == "data_freshness" and self._data is not None
+            if self.failed and not observed_anyway:
                 check = HealthCheck(
                     id=check_id, layer=layer, label=label,
                     state=CheckState.SKIPPED,
@@ -278,13 +352,17 @@ class _ChecklistBuilder:
                 )
             else:
                 # A check returns (state, message, blocking) with an optional
-                # trailing CheckLink
+                # trailing CheckLink — or a dict of HealthCheck kwargs
                 result = getattr(self, f"_check_{check_id}")()
-                state, message, blocking = result[:3]
-                link = result[3] if len(result) > 3 else None
-                check = HealthCheck(id=check_id, layer=layer, label=label,
-                                    state=state, message=message, blocking=blocking,
-                                    link=link)
+                if isinstance(result, dict):
+                    check = HealthCheck(id=check_id, layer=layer, label=label,
+                                        **result)
+                else:
+                    state, message, blocking = result[:3]
+                    link = result[3] if len(result) > 3 else None
+                    check = HealthCheck(id=check_id, layer=layer, label=label,
+                                        state=state, message=message, blocking=blocking,
+                                        link=link)
                 if check.blocking and check.state == CheckState.FAILED:
                     self.failed = True
             checks.append(check)
@@ -499,10 +577,16 @@ class _ChecklistBuilder:
                   "their own TTL.") % counts,
                 True)
 
-    # -- Layers 4-5: the external layers, read from stored on-demand probe
-    # results only. Never probed here — evaluation must be free of side
-    # effects on partner hosts — so "not recently checked" (STALE) is the
-    # resting state, and STALE never reaches the headline.
+    # -- Layers 4-5: the external layers. Each holds ONE evidence slot fed
+    # from three producers — the on-demand probe (PROBE), core's own trusted
+    # run record (INTERNAL: successes, and write-time-stamped failures), and
+    # the read-time text classification of unstamped failure rows
+    # (LOG_CLASSIFICATION). Disagreement resolves on the freshest
+    # observation, ties to the probe; the superseded observation is retained
+    # on the slot. Nothing here performs I/O against the partner's host —
+    # a successful scheduled run is real DNS, TCP, auth and bytes, strictly
+    # better than a synthetic probe, and it is what lets the diagnostic go
+    # green again after a fix instead of only red after a fault.
 
     @property
     def source_endpoint(self):
@@ -515,69 +599,272 @@ class _ChecklistBuilder:
                 self._source_endpoint = None
         return self._source_endpoint
 
-    def _latest_probe(self, check_id):
-        # Connection-scope rows only: station-scope checks carry a station
-        # link and are excluded from the connection's verdict by
-        # construction, not by discipline
-        return (SourceProbeResult.objects
-                .filter(connection=self.connection, station_link__isnull=True,
-                        check_id=check_id)
-                .order_by("-at")
-                .first())
+    @property
+    def drifted_link_ids(self):
+        """Enabled station links whose stored configuration no longer passes
+        validation — excluded from layer-5 evidence, or a fault in our own
+        configuration would be attributed to the partner's server."""
+        if self._drifted_ids is None:
+            self._drifted_ids = {
+                link.id
+                for link in self.connection.station_links.filter(enabled=True)
+                if station_link_drifted(link)
+            }
+        return self._drifted_ids
 
-    def _probe_backed_check(self, check_id, supported, unsupported_message):
-        row = self._latest_probe(check_id)
-        if row is None:
-            if not supported:
-                return CheckState.UNSUPPORTED, unsupported_message, False
-            return (CheckState.STALE,
-                    _("Not recently checked — no probe has run. External "
-                      "layers are probed on demand only."),
-                    False)
+    def _log_freshness_seconds(self):
+        return self.connection.interval * 60 * LOG_EVIDENCE_INTERVAL_MULTIPLIER
 
-        age_minutes = probe_age_minutes(self.now, row.at)
-        if (self.now - row.at).total_seconds() > PROBE_FRESHNESS_SECONDS:
-            return (CheckState.STALE,
-                    _("Not recently checked — the last on-demand probe ran "
-                      "%(minutes)d minute(s) ago, outside the 15-minute "
-                      "freshness window.") % {"minutes": age_minutes},
-                    False)
+    def _terminal_pull_logs(self, since):
+        """Terminal pull rows that constitute evidence: COMPLETED and
+        FAILED. SKIPPED rows merely look like evidence and are excluded by
+        the status filter."""
+        return (StationLinkActivityLog.objects
+                .filter(station_link__network_connection=self.connection,
+                        station_link__enabled=True,
+                        direction="pull",
+                        status__in=_TERMINAL_LOG_STATUSES,
+                        time__gte=since)
+                .order_by("-time"))
 
-        message = _("%(message)s (on-demand probe, %(minutes)d minute(s) ago)") % {
-            "message": row.message, "minutes": age_minutes,
+    def _render_evidence(self, evidence):
+        return _("%(message)s (%(origin)s, %(minutes)d minute(s) ago)") % {
+            "message": evidence.message,
+            "origin": PROVENANCE_LABELS[evidence.provenance],
+            "minutes": probe_age_minutes(self.now, evidence.at),
         }
-        if row.status == SourceCheckStatus.OK:
-            return CheckState.OK, message, True
-        if row.status == SourceCheckStatus.FAILED:
-            return CheckState.FAILED, message, True
-        if row.status == SourceCheckStatus.MALFORMED:
-            return (CheckState.UNSUPPORTED,
-                    _("The plugin returned a malformed result, which core "
-                      "does not trust: %(message)s") % {"message": row.message},
-                    False)
-        # An UNSUPPORTED probe row: the plugin declined at probe time
-        return CheckState.UNSUPPORTED, message, False
 
-    def _check_dns_resolution(self):
-        return self._probe_backed_check(
-            CHECK_DNS,
-            supported=self.source_endpoint is not None,
-            unsupported_message=_("This plugin does not name its source "
-                                  "endpoint, so core cannot probe DNS."),
+    # Probe evidence -------------------------------------------------------
+
+    def _probe_slot_row(self, layer_id):
+        """The decisive stored probe row for one external layer —
+        connection-scope rows only: station-scope checks carry a station
+        link and are excluded from the connection's verdict by
+        construction, not by discipline."""
+        check_ids = (CHECK_DNS, CHECK_TCP) if layer_id == 4 else (CHECK_SOURCE,)
+        rows = list(SourceProbeResult.objects
+                    .filter(connection=self.connection, station_link__isnull=True,
+                            check_id__in=check_ids)
+                    .order_by("-at")[:len(check_ids)])
+        if not rows:
+            return None
+        # Steps of one probe share their `at`; the decisive row of the
+        # newest probe is its failure if it has one, else its last step
+        batch = [row for row in rows if row.at == rows[0].at]
+        for row in batch:
+            if row.status == SourceCheckStatus.FAILED:
+                return row
+        for row in batch:
+            if row.check_id == CHECK_TCP:
+                return row
+        return batch[0]
+
+    def _probe_evidence(self, probe_row):
+        """A fresh OK/FAILED probe row as slot evidence; anything else
+        (stale, malformed, plugin-declined) is not evidence."""
+        if probe_row is None:
+            return None
+        if (self.now - probe_row.at).total_seconds() > PROBE_FRESHNESS_SECONDS:
+            return None
+        if probe_row.status == SourceCheckStatus.OK:
+            state = CheckState.OK
+        elif probe_row.status == SourceCheckStatus.FAILED:
+            state = CheckState.FAILED
+        else:
+            return None
+        # Probe messages are core-authored step summaries, already normalised
+        return Evidence(PROVENANCE_PROBE, state, probe_row.message, probe_row.at)
+
+    # Log evidence ---------------------------------------------------------
+
+    def _log_evidence(self, layer_id):
+        """The freshest activity-log observation bearing on one external
+        layer, within 2x the connection's interval."""
+        window_start = self.now - timedelta(seconds=self._log_freshness_seconds())
+        for log in self._terminal_pull_logs(window_start):
+            evidence = self._evidence_from_log(log, layer_id)
+            if evidence is not None:
+                return evidence
+        return None
+
+    def _evidence_from_log(self, log, layer_id):
+        succeeded = (log.status == StationLinkActivityLog.ActivityStatus.COMPLETED
+                     and log.success)
+        if succeeded:
+            if layer_id == 4:
+                # The strongest layer-4 evidence in the system: real DNS,
+                # TCP and a completed exchange — even a zero-sources run
+                return Evidence(
+                    PROVENANCE_INTERNAL, CheckState.OK,
+                    _("A scheduled run reached the source host over the "
+                      "network and completed."),
+                    log.time,
+                )
+            if log.station_link_id in self.drifted_link_ids:
+                return None
+            if log.sources_count == 0:
+                # The one thing a zero-sources success did not do is
+                # transfer bytes — no layer-5 OK from it
+                return None
+            return Evidence(
+                PROVENANCE_INTERNAL, CheckState.OK,
+                _("A scheduled run authenticated against the source and "
+                  "completed."),
+                log.time,
+            )
+
+        # A terminal failure row. The write-time stamp is the trusted tier;
+        # the read-time text rules run only on rows the writer did not stamp
+        if log.error_category is not None:
+            category = log.error_category
+            layer = log.error_layer
+            provenance = PROVENANCE_INTERNAL
+            message = category_message(category)
+        else:
+            outcome = classify_failure_text(log.message)
+            if outcome is None:
+                # Genuinely ambiguous: no classification rather than a guess
+                return None
+            layer = outcome.layer
+            provenance = PROVENANCE_LOG_CLASSIFICATION
+            message = outcome.message
+
+        # The layer belongs to the rule/stamp; no layer means the failure
+        # stays layer-6 detail and feeds no external slot
+        if layer != layer_id:
+            return None
+        if layer_id == 5 and log.station_link_id in self.drifted_link_ids:
+            return None
+        return Evidence(provenance, CheckState.FAILED, message, log.time)
+
+    # The sources count ----------------------------------------------------
+
+    def _sources_count_evidence(self):
+        """The sources count qualifies layer 5 **only when layer 6 is
+        already red**: every station's data stale and every terminal log in
+        layer 6's own window resolved zero source items → FAILED; any
+        non-zero → OK, the fault is downstream. A count nobody reported
+        (NULL) is silence, and silence is never read as a fault."""
+        data_check = self._data_freshness()[0]
+        if data_check[0] != CheckState.FAILED:
+            # Layer 6 green or merely partial: no standalone alarm — a
+            # quiet interval on a healthy connection raises nothing
+            return None
+
+        thresholds = connection_thresholds(self.connection)
+        logs = (self._terminal_pull_logs(self.now - thresholds.freshness_error_limit)
+                .exclude(station_link_id__in=self.drifted_link_ids))
+        counts = logs.aggregate(
+            total=Count("id"),
+            offered=Count("id", filter=Q(sources_count__gt=0)),
+            unknown=Count("id", filter=Q(sources_count__isnull=True)),
+            newest=Max("time"),
+            newest_offered=Max("time", filter=Q(sources_count__gt=0)),
+        )
+        if not counts["total"]:
+            return None
+        if counts["offered"]:
+            return Evidence(
+                PROVENANCE_INTERNAL, CheckState.OK,
+                _("Runs within the data-freshness window found source data "
+                  "on offer — the fault is downstream of the source."),
+                counts["newest_offered"],
+            )
+        if counts["unknown"]:
+            return None
+        return Evidence(
+            PROVENANCE_INTERNAL, CheckState.FAILED,
+            _("Data is stale and every run within the data-freshness "
+              "window resolved zero source items — the source is offering "
+              "no data."),
+            counts["newest"],
         )
 
-    def _check_tcp_connect(self):
-        return self._probe_backed_check(
-            CHECK_TCP,
+    # The slot -------------------------------------------------------------
+
+    def _external_slot(self, layer_id, supported, unsupported_message):
+        probe_row = self._probe_slot_row(layer_id)
+
+        candidates = []
+        probe_evidence = self._probe_evidence(probe_row)
+        if probe_evidence is not None:
+            candidates.append(probe_evidence)
+        log_evidence = self._log_evidence(layer_id)
+        if log_evidence is not None:
+            candidates.append(log_evidence)
+        if layer_id == 5:
+            sources_evidence = self._sources_count_evidence()
+            if sources_evidence is not None:
+                candidates.append(sources_evidence)
+
+        if candidates:
+            # Freshest observation wins; ties go to the probe
+            winner = max(candidates,
+                         key=lambda e: (e.at, e.provenance == PROVENANCE_PROBE))
+            losers = [c for c in candidates if c is not winner]
+            superseded = max(losers, key=lambda e: e.at) if losers else None
+            return {
+                "state": winner.state,
+                "message": self._render_evidence(winner),
+                "blocking": True,
+                "provenance": winner.provenance,
+                "superseded": superseded,
+                "superseded_message": (self._render_evidence(superseded)
+                                       if superseded else None),
+            }
+
+        # No usable evidence: rest at STALE (or surface a fresh
+        # malformed/declined probe row), never at FAILED
+        if probe_row is not None:
+            fresh = (self.now - probe_row.at).total_seconds() <= PROBE_FRESHNESS_SECONDS
+            if fresh and probe_row.status == SourceCheckStatus.MALFORMED:
+                return {
+                    "state": CheckState.UNSUPPORTED,
+                    "message": _("The plugin returned a malformed result, "
+                                 "which core does not trust: %(message)s")
+                               % {"message": probe_row.message},
+                    "blocking": False,
+                }
+            if fresh and probe_row.status == SourceCheckStatus.UNSUPPORTED:
+                return {
+                    "state": CheckState.UNSUPPORTED,
+                    "message": _("%(message)s (on-demand probe, %(minutes)d "
+                                 "minute(s) ago)")
+                               % {"message": probe_row.message,
+                                  "minutes": probe_age_minutes(self.now, probe_row.at)},
+                    "blocking": False,
+                }
+            return {
+                "state": CheckState.STALE,
+                "message": _("Not recently checked — the last on-demand probe "
+                             "ran %(minutes)d minute(s) ago, outside the "
+                             "15-minute freshness window.")
+                           % {"minutes": probe_age_minutes(self.now, probe_row.at)},
+                "blocking": False,
+            }
+        if supported:
+            return {
+                "state": CheckState.STALE,
+                "message": _("Not recently checked — no probe has run and no "
+                             "recent run left usable evidence. External "
+                             "layers are probed on demand only."),
+                "blocking": False,
+            }
+        return {"state": CheckState.UNSUPPORTED, "message": unsupported_message,
+                "blocking": False}
+
+    def _check_network_path(self):
+        return self._external_slot(
+            4,
             supported=self.source_endpoint is not None,
             unsupported_message=_("This plugin does not name its source "
-                                  "endpoint, so core cannot probe a TCP "
-                                  "connection."),
+                                  "endpoint, so core cannot probe the "
+                                  "network path."),
         )
 
     def _check_source_check(self):
-        return self._probe_backed_check(
-            CHECK_SOURCE,
+        return self._external_slot(
+            5,
             supported=connection_implements_check_source(self.connection),
             unsupported_message=_("This plugin does not implement the source "
                                   "check."),
@@ -588,7 +875,18 @@ class _ChecklistBuilder:
     # none -> OK — one misconfigured station cannot turn a healthy
     # connection red.
 
+    def _data_freshness(self):
+        """Memoized ``(check_result, stale_count)`` — computed once whether
+        reached from the ladder or consulted early by the sources-count
+        qualification of layer 5."""
+        if self._data is None:
+            self._data = self._compute_data_freshness()
+        return self._data
+
     def _check_data_freshness(self):
+        return self._data_freshness()[0]
+
+    def _compute_data_freshness(self):
         links = annotate_station_pull_activity(
             self.connection.station_links.filter(enabled=True)
         )
@@ -612,9 +910,10 @@ class _ChecklistBuilder:
                 aging += 1
 
         if not total:
-            return (CheckState.OK,
-                    _("This connection has no enabled station links."),
-                    True)
+            return ((CheckState.OK,
+                     _("This connection has no enabled station links."),
+                     True),
+                    0)
 
         link = CheckLink(
             url=reverse("network_connection_monitoring", args=(self.connection.id,)),
@@ -632,18 +931,20 @@ class _ChecklistBuilder:
             else:
                 message = _("Data is current on all %(total)d enabled "
                             "station(s).") % counts
-            return CheckState.OK, message, True, link
+            return (CheckState.OK, message, True, link), 0
         if stale == total:
-            return (CheckState.FAILED,
-                    _("All %(total)d enabled station(s) have stale data — no "
-                      "recent observations within the connection's freshness "
-                      "limit.") % counts,
-                    True, link)
-        return (CheckState.WARNING,
-                _("%(stale)d of %(total)d enabled stations have stale data — "
-                  "no recent observations within the connection's freshness "
-                  "limit.") % counts,
-                True, link)
+            return ((CheckState.FAILED,
+                     _("All %(total)d enabled station(s) have stale data — no "
+                       "recent observations within the connection's freshness "
+                       "limit.") % counts,
+                     True, link),
+                    stale)
+        return ((CheckState.WARNING,
+                 _("%(stale)d of %(total)d enabled stations have stale data — "
+                   "no recent observations within the connection's freshness "
+                   "limit.") % counts,
+                 True, link),
+                stale)
 
 
 def store_connection_health(connection, checklist, now=None):

--- a/adl/src/adl/monitoring/templates/monitoring/connection_health.html
+++ b/adl/src/adl/monitoring/templates/monitoring/connection_health.html
@@ -38,6 +38,11 @@
             white-space: nowrap;
         }
 
+        .health-check__superseded {
+            color: var(--w-color-text-meta);
+            margin-top: 0.25rem;
+        }
+
         .health-probe-form {
             margin: 0.5rem 0 1.5rem;
         }

--- a/adl/src/adl/monitoring/templates/monitoring/partials/health_check_table.html
+++ b/adl/src/adl/monitoring/templates/monitoring/partials/health_check_table.html
@@ -3,6 +3,7 @@ One band of diagnostic checks. Colour carries the verdict axis only —
 epistemic states (skipped, stale, unsupported, disabled, misconfigured)
 render grey via --muted and are distinguished by wording.
 {% endcomment %}
+{% load i18n %}
 <table class="listing">
     <tbody>
     {% for check in checks %}
@@ -17,6 +18,12 @@ render grey via --muted and are distinguished by wording.
                 {{ check.message }}
                 {% if check.link %}
                     <a href="{{ check.link.url }}">{{ check.link.label }}</a>
+                {% endif %}
+                {% if check.superseded_message %}
+                    {# The slot retains the observation the winner displaced #}
+                    <p class="health-check__superseded">
+                        {% blocktrans with observation=check.superseded_message %}Superseded: {{ observation }}{% endblocktrans %}
+                    </p>
                 {% endif %}
             </td>
         </tr>

--- a/adl/src/adl/monitoring/tests/test_health.py
+++ b/adl/src/adl/monitoring/tests/test_health.py
@@ -25,12 +25,18 @@ from adl.core.tests.factories import (
 from adl.monitoring.constants import (
     LAYER_DATA,
     LAYER_LOCKS,
+    LAYER_NETWORK,
     LAYER_SCHEDULER,
+    LAYER_SOURCE,
     LAYER_WORKER,
+    PROVENANCE_INTERNAL,
+    PROVENANCE_LOG_CLASSIFICATION,
+    PROVENANCE_PROBE,
     CheckState,
 )
 from adl.monitoring.health import (
     evaluate_connection_health,
+    station_link_drifted,
     store_connection_health,
 )
 from adl.monitoring.models import (
@@ -87,7 +93,8 @@ class HealthEvaluatorTestCase(TestCase):
         return matches[0]
 
 
-PROBE_CHECK_IDS = ("dns_resolution", "tcp_connect", "source_check")
+# One evidence slot per external layer
+PROBE_CHECK_IDS = ("network_path", "source_check")
 
 
 class HealthyConnectionTests(HealthEvaluatorTestCase):
@@ -340,10 +347,10 @@ class LocksLayerTests(HealthEvaluatorTestCase):
         self.assertFalse(check.blocking)
 
 
-class SourceProbeLayerTests(HealthEvaluatorTestCase):
-    """Layers 4-5 are external and on-demand: the evaluator only ever reads
-    stored probe rows, rests at STALE (or UNSUPPORTED where the plugin has
-    no contract), and STALE never reaches the headline."""
+class ExternalLayerTestCase(HealthEvaluatorTestCase):
+    """Shared fixtures for the external layers 4-5: stored probe rows and
+    terminal activity-log rows, the two producers their evidence slots
+    resolve between."""
 
     def probe_row(self, check_id, status, age=None, layer="network",
                   station_link=None, message="probe message", category=None):
@@ -360,6 +367,26 @@ class SourceProbeLayerTests(HealthEvaluatorTestCase):
             at=dj_tz.now() - (age or timedelta(0)),
         )
 
+    def log_row(self, age=None, station_link=None, status=None, success=True,
+                message="", sources_count=None, error_category=None,
+                error_layer=None):
+        from adl.monitoring.models import StationLinkActivityLog
+
+        if status is None:
+            status = (StationLinkActivityLog.ActivityStatus.COMPLETED
+                      if success else StationLinkActivityLog.ActivityStatus.FAILED)
+        return StationLinkActivityLog.objects.create(
+            station_link=station_link or self.link,
+            direction="pull",
+            status=status,
+            success=success,
+            message=message,
+            sources_count=sources_count,
+            error_category=error_category,
+            error_layer=error_layer,
+            time=dj_tz.now() - (age or timedelta(0)),
+        )
+
     def with_supported_contract(self):
         """A connection whose plugin implements the whole contract, without
         needing a polymorphic subclass: the endpoint via an instance
@@ -372,6 +399,12 @@ class SourceProbeLayerTests(HealthEvaluatorTestCase):
         )
         patcher.start()
         self.addCleanup(patcher.stop)
+
+
+class SourceProbeLayerTests(ExternalLayerTestCase):
+    """The on-demand probe as slot evidence: the evaluator only ever reads
+    stored probe rows, rests at STALE (or UNSUPPORTED where the plugin has
+    no contract), and STALE never reaches the headline."""
 
     def test_unsupported_contract_reports_unsupported_never_stale(self):
         self.make_healthy()
@@ -403,7 +436,7 @@ class SourceProbeLayerTests(HealthEvaluatorTestCase):
 
         checklist = self.evaluate()
 
-        self.assertEqual(self.check(checklist, "dns_resolution").state, CheckState.STALE)
+        self.assertEqual(self.check(checklist, "network_path").state, CheckState.STALE)
         self.assertEqual(checklist.status, CheckState.OK)
 
     def test_result_inside_fifteen_minutes_is_fresh(self):
@@ -413,10 +446,11 @@ class SourceProbeLayerTests(HealthEvaluatorTestCase):
 
         checklist = self.evaluate()
 
-        check = self.check(checklist, "dns_resolution")
+        check = self.check(checklist, "network_path")
         self.assertEqual(check.state, CheckState.OK)
         # The rendered message carries the result's age and origin
         self.assertIn("on-demand probe", check.message)
+        self.assertEqual(check.provenance, PROVENANCE_PROBE)
 
     def test_fresh_failed_dns_leads_the_headline_and_skips_below(self):
         from adl.monitoring.constants import LAYER_NETWORK
@@ -430,8 +464,8 @@ class SourceProbeLayerTests(HealthEvaluatorTestCase):
 
         self.assertEqual(checklist.status, CheckState.FAILED)
         self.assertEqual(checklist.first_failing_layer, LAYER_NETWORK)
-        self.assertEqual(checklist.headline_check_id, "dns_resolution")
-        for check_id in ("tcp_connect", "source_check", "data_freshness"):
+        self.assertEqual(checklist.headline_check_id, "network_path")
+        for check_id in ("source_check", "data_freshness"):
             self.assertEqual(self.check(checklist, check_id).state,
                              CheckState.SKIPPED, check_id)
 
@@ -462,7 +496,7 @@ class SourceProbeLayerTests(HealthEvaluatorTestCase):
 
         checklist = self.evaluate()
 
-        self.assertEqual(self.check(checklist, "dns_resolution").state, CheckState.STALE)
+        self.assertEqual(self.check(checklist, "network_path").state, CheckState.STALE)
         self.assertEqual(checklist.status, CheckState.OK)
 
     def test_malformed_probe_row_reports_unsupported_not_a_verdict(self):
@@ -487,6 +521,343 @@ class SourceProbeLayerTests(HealthEvaluatorTestCase):
         for check_id in PROBE_CHECK_IDS:
             self.assertEqual(self.check(checklist, check_id).state,
                              CheckState.SKIPPED, check_id)
+
+
+class LogEvidenceTests(ExternalLayerTestCase):
+    """What already happened counts as evidence about layers 4-5: successes
+    are OK evidence, write-time-stamped failures are trusted, unstamped
+    failures fall back to the read-time text rules — and rows that merely
+    look like evidence (SKIPPED, drifted links) are excluded."""
+
+    def test_successful_run_contributes_ok_evidence_to_both_external_layers(self):
+        self.make_healthy()
+        self.log_row(age=timedelta(minutes=5), sources_count=3)
+
+        checklist = self.evaluate()
+
+        for check_id in PROBE_CHECK_IDS:
+            check = self.check(checklist, check_id)
+            self.assertEqual(check.state, CheckState.OK, check_id)
+            self.assertEqual(check.provenance, PROVENANCE_INTERNAL, check_id)
+
+    def test_log_evidence_needs_no_probe_contract(self):
+        # The stub plugin implements no source-check contract, yet a real
+        # run is still evidence — the ratchet can go green after a fix
+        self.make_healthy()
+        self.log_row(age=timedelta(minutes=5), sources_count=3)
+
+        checklist = self.evaluate()
+
+        self.assertEqual(self.check(checklist, "network_path").state, CheckState.OK)
+
+    def test_zero_sources_success_is_layer_four_ok_but_no_layer_five_ok(self):
+        self.make_healthy()
+        self.log_row(age=timedelta(minutes=5), sources_count=0)
+
+        checklist = self.evaluate()
+
+        self.assertEqual(self.check(checklist, "network_path").state, CheckState.OK)
+        # The one thing the run did not do is transfer bytes
+        self.assertNotEqual(self.check(checklist, "source_check").state, CheckState.OK)
+
+    def test_skipped_rows_are_not_evidence(self):
+        # A lock collision must not manufacture fake layer-4 OK evidence
+        from adl.monitoring.models import StationLinkActivityLog
+
+        self.make_healthy()
+        self.log_row(age=timedelta(minutes=5), success=False,
+                     status=StationLinkActivityLog.ActivityStatus.SKIPPED)
+
+        checklist = self.evaluate()
+
+        for check_id in PROBE_CHECK_IDS:
+            self.assertNotEqual(self.check(checklist, check_id).state,
+                                CheckState.OK, check_id)
+
+    def test_write_time_stamped_failure_is_trusted_and_renders_normalised_text(self):
+        self.make_healthy()
+        raw = "530 Login incorrect: password 'hunter2'"
+        self.log_row(age=timedelta(minutes=5), success=False, message=raw,
+                     error_category="AUTH_FAILED", error_layer=5)
+
+        checklist = self.evaluate()
+
+        check = self.check(checklist, "source_check")
+        self.assertEqual(check.state, CheckState.FAILED)
+        self.assertEqual(check.provenance, PROVENANCE_INTERNAL)
+        self.assertNotIn("hunter2", check.message)
+        self.assertEqual(checklist.first_failing_layer, LAYER_SOURCE)
+
+    def test_unstamped_failure_falls_back_to_read_time_classification(self):
+        self.make_healthy()
+        self.log_row(age=timedelta(minutes=5), success=False,
+                     message="[Errno -2] Name or service not known")
+
+        checklist = self.evaluate()
+
+        check = self.check(checklist, "network_path")
+        self.assertEqual(check.state, CheckState.FAILED)
+        self.assertEqual(check.provenance, PROVENANCE_LOG_CLASSIFICATION)
+        self.assertNotIn("Errno", check.message)
+        self.assertEqual(checklist.first_failing_layer, LAYER_NETWORK)
+
+    def test_ambiguous_failure_text_yields_no_classification(self):
+        self.make_healthy()
+        self.log_row(age=timedelta(minutes=5), success=False,
+                     message="Something went wrong")
+
+        checklist = self.evaluate()
+
+        for check_id in PROBE_CHECK_IDS:
+            self.assertEqual(self.check(checklist, check_id).state,
+                             CheckState.UNSUPPORTED, check_id)
+        self.assertEqual(checklist.status, CheckState.OK)
+
+    def test_rule_without_a_layer_creates_no_external_slot(self):
+        # "timed out" cannot tell a connect timeout from a read timeout;
+        # the rule claims the category but declines the layer, so the row
+        # stays layer-6 detail
+        self.make_healthy()
+        self.log_row(age=timedelta(minutes=5), success=False,
+                     message="Connection timed out")
+
+        checklist = self.evaluate()
+
+        for check_id in PROBE_CHECK_IDS:
+            self.assertNotEqual(self.check(checklist, check_id).state,
+                                CheckState.FAILED, check_id)
+        self.assertEqual(checklist.status, CheckState.OK)
+
+    def test_log_older_than_twice_the_interval_is_not_evidence(self):
+        # Interval is 15 minutes, so the log freshness window is 30
+        self.make_healthy()
+        self.log_row(age=timedelta(minutes=35), sources_count=3)
+
+        checklist = self.evaluate()
+
+        for check_id in PROBE_CHECK_IDS:
+            self.assertNotEqual(self.check(checklist, check_id).state,
+                                CheckState.OK, check_id)
+
+    def test_drifted_station_link_is_excluded_from_layer_five_evidence_only(self):
+        self.make_healthy()
+        self.log_row(age=timedelta(minutes=5), success=False,
+                     message="530 Login incorrect",
+                     error_category="AUTH_FAILED", error_layer=5)
+
+        with patch("adl.monitoring.health.station_link_drifted", return_value=True):
+            checklist = self.evaluate()
+
+        # Our own configuration fault is not attributed to the partner
+        self.assertNotEqual(self.check(checklist, "source_check").state,
+                            CheckState.FAILED)
+        self.assertEqual(checklist.status, CheckState.OK)
+
+    def test_drifted_station_link_success_still_feeds_layer_four(self):
+        self.make_healthy()
+        self.log_row(age=timedelta(minutes=5), sources_count=3)
+
+        with patch("adl.monitoring.health.station_link_drifted", return_value=True):
+            checklist = self.evaluate()
+
+        self.assertEqual(self.check(checklist, "network_path").state, CheckState.OK)
+        self.assertNotEqual(self.check(checklist, "source_check").state, CheckState.OK)
+
+
+class SlotResolutionTests(ExternalLayerTestCase):
+    """One slot per external layer: freshest observation wins, ties go to
+    the probe, and the superseded observation is retained with its
+    provenance."""
+
+    def test_fresher_log_beats_an_older_probe_and_retains_it(self):
+        self.make_healthy()
+        self.with_supported_contract()
+        self.probe_row("dns_resolution", "FAILED", age=timedelta(minutes=10),
+                       category="DNS_FAILURE")
+        self.log_row(age=timedelta(minutes=2), sources_count=3)
+
+        checklist = self.evaluate()
+
+        check = self.check(checklist, "network_path")
+        self.assertEqual(check.state, CheckState.OK)
+        self.assertEqual(check.provenance, PROVENANCE_INTERNAL)
+        self.assertIsNotNone(check.superseded)
+        self.assertEqual(check.superseded.provenance, PROVENANCE_PROBE)
+        self.assertEqual(check.superseded.state, CheckState.FAILED)
+        self.assertIsNotNone(check.superseded_message)
+
+    def test_fresher_probe_beats_an_older_log(self):
+        self.make_healthy()
+        self.with_supported_contract()
+        self.log_row(age=timedelta(minutes=10), success=False,
+                     message="[Errno 111] Connection refused")
+        self.probe_row("dns_resolution", "OK", age=timedelta(minutes=2))
+        self.probe_row("tcp_connect", "OK", age=timedelta(minutes=2))
+
+        checklist = self.evaluate()
+
+        check = self.check(checklist, "network_path")
+        self.assertEqual(check.state, CheckState.OK)
+        self.assertEqual(check.provenance, PROVENANCE_PROBE)
+        self.assertEqual(check.superseded.provenance, PROVENANCE_LOG_CLASSIFICATION)
+
+    def test_a_tie_resolves_to_the_probe(self):
+        self.make_healthy()
+        self.with_supported_contract()
+        at = dj_tz.now() - timedelta(minutes=5)
+        row = self.probe_row("dns_resolution", "OK")
+        row.at = at
+        row.save()
+        log = self.log_row(success=False, message="Connection refused")
+        log.time = at
+        log.save()
+
+        checklist = self.evaluate()
+
+        self.assertEqual(self.check(checklist, "network_path").provenance, PROVENANCE_PROBE)
+
+
+class SourcesCountTests(ExternalLayerTestCase):
+    """The sources count qualifies layer 5 only when layer 6 is already
+    red — no standalone alarm, and silence (NULL) is never read as fault.
+    The window is layer 6's own freshness-error limit (12x the 15-minute
+    interval = 180 minutes)."""
+
+    def stale_data(self):
+        ObservationRecordFactory(
+            station=self.link.station,
+            connection=self.connection,
+            time=dj_tz.now() - timedelta(hours=6),
+        )
+
+    def test_data_stale_and_every_terminal_log_at_zero_fails_layer_five(self):
+        self.make_healthy()
+        self.stale_data()
+        # Old enough to be outside the 30-minute plain-evidence window, so
+        # only the sources-count rule speaks for layer 5
+        self.log_row(age=timedelta(minutes=100), sources_count=0)
+        self.log_row(age=timedelta(minutes=60), sources_count=0)
+
+        checklist = self.evaluate()
+
+        self.assertEqual(checklist.status, CheckState.FAILED)
+        self.assertEqual(checklist.first_failing_layer, LAYER_SOURCE)
+        check = self.check(checklist, "source_check")
+        self.assertEqual(check.state, CheckState.FAILED)
+        self.assertEqual(check.provenance, PROVENANCE_INTERNAL)
+
+    def test_layer_six_still_reports_its_observed_verdict_below_the_sources_verdict(self):
+        self.make_healthy()
+        self.stale_data()
+        self.log_row(age=timedelta(minutes=60), sources_count=0)
+
+        checklist = self.evaluate()
+
+        # The data row triggered the layer-5 verdict; hiding it as SKIPPED
+        # would misreport a genuinely observed fact
+        self.assertEqual(self.check(checklist, "data_freshness").state,
+                         CheckState.FAILED)
+
+    def test_any_non_zero_count_reports_layer_five_ok_and_anchors_to_data(self):
+        self.make_healthy()
+        self.stale_data()
+        self.log_row(age=timedelta(minutes=100), sources_count=0)
+        self.log_row(age=timedelta(minutes=60), sources_count=4)
+
+        checklist = self.evaluate()
+
+        self.assertEqual(self.check(checklist, "source_check").state, CheckState.OK)
+        self.assertEqual(checklist.status, CheckState.FAILED)
+        self.assertEqual(checklist.first_failing_layer, LAYER_DATA)
+
+    def test_with_data_green_the_sources_count_changes_nothing(self):
+        # The date-rollover false alarm, dissolved: zero sources on a
+        # healthy connection raises no alarm
+        self.make_healthy()
+        ObservationRecordFactory(
+            station=self.link.station, connection=self.connection,
+            time=dj_tz.now() - timedelta(minutes=10),
+        )
+        self.log_row(age=timedelta(minutes=60), sources_count=0)
+
+        checklist = self.evaluate()
+
+        self.assertEqual(checklist.status, CheckState.OK)
+        self.assertNotEqual(self.check(checklist, "source_check").state,
+                            CheckState.FAILED)
+
+    def test_partial_staleness_is_not_red_so_the_count_stays_silent(self):
+        # One of two stations stale rolls layer 6 up to WARNING, not
+        # FAILED — the count qualifies layer 5 only when layer 6 is red
+        fresh_link = StationLinkFactory(network_connection=self.connection)
+        self.make_healthy()
+        self.stale_data()
+        ObservationRecordFactory(
+            station=fresh_link.station, connection=self.connection,
+            time=dj_tz.now() - timedelta(minutes=10),
+        )
+        self.log_row(age=timedelta(minutes=60), sources_count=0)
+        self.log_row(age=timedelta(minutes=60), station_link=fresh_link,
+                     sources_count=0)
+
+        checklist = self.evaluate()
+
+        self.assertNotEqual(self.check(checklist, "source_check").state,
+                            CheckState.FAILED)
+        self.assertEqual(checklist.status, CheckState.WARNING)
+        self.assertEqual(checklist.first_failing_layer, LAYER_DATA)
+
+    def test_a_null_count_disqualifies_the_zero_sources_claim(self):
+        # NULL means "did not look" — not every terminal log is at 0, so
+        # the diagnostic declines rather than reading silence as fault
+        self.make_healthy()
+        self.stale_data()
+        self.log_row(age=timedelta(minutes=100), sources_count=0)
+        self.log_row(age=timedelta(minutes=60), sources_count=None)
+
+        checklist = self.evaluate()
+
+        self.assertNotEqual(self.check(checklist, "source_check").state,
+                            CheckState.FAILED)
+        self.assertEqual(checklist.first_failing_layer, LAYER_DATA)
+
+    def test_drifted_links_are_excluded_from_the_sources_count(self):
+        # The only zero-sources logs belong to a drifted link; a fault in
+        # our configuration must not indict the partner's server
+        self.make_healthy()
+        self.stale_data()
+        self.log_row(age=timedelta(minutes=60), sources_count=0)
+
+        with patch("adl.monitoring.health.station_link_drifted", return_value=True):
+            checklist = self.evaluate()
+
+        self.assertNotEqual(self.check(checklist, "source_check").state,
+                            CheckState.FAILED)
+        self.assertEqual(checklist.first_failing_layer, LAYER_DATA)
+
+
+class StationLinkDriftedTests(TestCase):
+    """The drift predicate is full_clean() and nothing more; only
+    ValidationError means drift — a crash in a validator is not evidence
+    the configuration is wrong."""
+
+    def test_a_valid_stored_link_is_not_drifted(self):
+        self.assertFalse(station_link_drifted(StationLinkFactory()))
+
+    def test_a_link_failing_validation_is_drifted(self):
+        from adl.core.models import StationLink
+
+        # Required fields missing: full_clean raises ValidationError
+        self.assertTrue(station_link_drifted(StationLink()))
+
+    def test_a_crashing_validator_makes_no_drift_claim(self):
+        class ExplodingLink:
+            id = 99
+
+            def full_clean(self, validate_unique=True):
+                raise RuntimeError("boom")
+
+        self.assertFalse(station_link_drifted(ExplodingLink()))
 
 
 class StoredVerdictTests(HealthEvaluatorTestCase):

--- a/adl/src/adl/monitoring/tests/test_read_time_classification.py
+++ b/adl/src/adl/monitoring/tests/test_read_time_classification.py
@@ -1,0 +1,101 @@
+"""
+Tests for the read-time classification fallback: ordered, first-match text
+rules with binary confidence, run only over rows the write-time contract did
+not stamp. The layer belongs to the rule, not the category — an ambiguous
+message declines rather than guesses — and every outcome carries the rule's
+normalised text, never the raw message.
+"""
+
+from django.test import SimpleTestCase
+
+from adl.core.classification import FAILURE_CATEGORIES
+from adl.monitoring.classification import (
+    READ_TIME_RULES,
+    category_message,
+    classify_failure_text,
+)
+
+
+class ReadTimeRuleTableTests(SimpleTestCase):
+    def test_every_rule_draws_from_the_closed_category_vocabulary(self):
+        for rule in READ_TIME_RULES:
+            self.assertIn(rule.category, FAILURE_CATEGORIES, rule.needle)
+
+    def test_every_rule_layer_is_external_or_declined(self):
+        for rule in READ_TIME_RULES:
+            self.assertIn(rule.layer, (4, 5, None), rule.needle)
+
+
+class ClassifyFailureTextTests(SimpleTestCase):
+    def test_auth_failure_text_classifies_to_the_source_layer(self):
+        outcome = classify_failure_text("530 Login authentication failed")
+
+        self.assertIsNotNone(outcome)
+        self.assertEqual(outcome.category, "AUTH_FAILED")
+        self.assertEqual(outcome.layer, 5)
+
+    def test_dns_failure_text_classifies_to_the_network_layer(self):
+        outcome = classify_failure_text(
+            "[Errno -2] Name or service not known"
+        )
+
+        self.assertIsNotNone(outcome)
+        self.assertEqual(outcome.category, "DNS_FAILURE")
+        self.assertEqual(outcome.layer, 4)
+
+    def test_connection_refused_classifies_to_the_network_layer(self):
+        outcome = classify_failure_text("[Errno 111] Connection refused")
+
+        self.assertEqual(outcome.category, "TCP_REFUSED")
+        self.assertEqual(outcome.layer, 4)
+
+    def test_timeout_text_claims_the_category_but_declines_the_layer(self):
+        # A plugin that collapses a connect timeout and a read timeout into
+        # one string: the text rule must decline where a type rule could
+        # claim — a rule with no layer stays layer-6 detail
+        outcome = classify_failure_text("Connection timed out")
+
+        self.assertEqual(outcome.category, "TCP_TIMEOUT")
+        self.assertIsNone(outcome.layer)
+
+    def test_missing_path_classifies_to_the_source_layer(self):
+        outcome = classify_failure_text(
+            "550 /data/observations: No such file or directory"
+        )
+
+        self.assertEqual(outcome.category, "PATH_NOT_FOUND")
+        self.assertEqual(outcome.layer, 5)
+
+    def test_genuinely_ambiguous_text_yields_no_classification(self):
+        # The headline must never confidently name the wrong layer
+        self.assertIsNone(classify_failure_text("Something went wrong"))
+        self.assertIsNone(classify_failure_text(""))
+        self.assertIsNone(classify_failure_text(None))
+
+    def test_matching_is_case_insensitive(self):
+        outcome = classify_failure_text("CONNECTION REFUSED by remote host")
+
+        self.assertEqual(outcome.category, "TCP_REFUSED")
+
+    def test_first_match_wins_over_later_rules(self):
+        # Both an auth needle and a timeout needle appear; the earlier,
+        # more specific rule claims the row
+        outcome = classify_failure_text(
+            "Login incorrect (control connection timed out)"
+        )
+
+        self.assertEqual(outcome.category, "AUTH_FAILED")
+
+    def test_outcome_carries_normalised_text_never_the_raw_message(self):
+        raw = "530 Login incorrect: user 'nma-user' password 'hunter2'"
+
+        outcome = classify_failure_text(raw)
+
+        self.assertNotIn("hunter2", outcome.message)
+        self.assertEqual(outcome.message, category_message("AUTH_FAILED"))
+
+
+class CategoryMessageTests(SimpleTestCase):
+    def test_every_category_has_a_normalised_message(self):
+        for category in FAILURE_CATEGORIES:
+            self.assertTrue(category_message(category), category)


### PR DESCRIPTION
Closes #182. Part of the per-connection ingestion diagnostic (spec: #171, decision sections 8–9).

## What this does

Makes what already happened count as evidence about layers 4–5, so the diagnostic can name an external fault without anyone pressing the probe button — and can go green again after a fix, not only red after a fault.

- **Read-time classification** (`monitoring/classification.py`): ordered, first-match text rules with binary confidence, run only on rows the write-time contract did not stamp, recomputed on every read and never written back — improving the rule table retroactively corrects every historical row. The layer belongs to the rule: a `timed out` rule claims the category but declines the layer and stays layer-6 detail. Ambiguous text yields no classification. Outcomes carry normalised category text, never the raw message.
- **One evidence slot per external layer** (`network_path`, `source_check`) with provenance `INTERNAL` / `PROBE` / `LOG_CLASSIFICATION`. Disagreement resolves on the freshest observation, ties to the probe; log freshness is 2× the connection's interval; the superseded observation is retained on the slot and rendered on the page.
- **Successes are evidence**: a completed run is layer-4 and layer-5 `OK` (`INTERNAL`); a zero-sources success remains the strongest layer-4 evidence but contributes no layer-5 `OK`.
- **Two exclusions, both corrections forced during charting**: `SKIPPED` rows are not evidence (a lock collision must not manufacture layer-4 `OK`), and drifted station links (`full_clean()`-based predicate, only `ValidationError` counts) are excluded from layer-5 evidence.
- **The sources count qualifies layer 5 only when layer 6 is already red**: every station stale and every terminal log in layer 6's own freshness window at `sources_count = 0` → layer 5 `FAILED`; any non-zero → `OK`, fault downstream. `NULL` counts disqualify the claim — silence is never read as fault. When the count triggers the verdict, the data row still shows its genuinely observed state rather than `SKIPPED`.

## Testing

- 12 new classifier tests at the module seam; 16 new evaluator-seam tests (log evidence, slot resolution, sources count, drift predicate) driven from ordinary domain rows.
- Full suite: 300 tests, all passing.