### PR TITLE
feat: configuration drift — MISCONFIGURED precondition band

### DIFF
--- a/adl/src/adl/core/tests/test_runner.py
+++ b/adl/src/adl/core/tests/test_runner.py
@@ -46,3 +46,24 @@ class RunnerTests(TestCase):
         # Only enabled link is processed and appears in results
         self.assertIn(sl_enabled.station.id, results)
         self.assertNotIn(sl_disabled.station.id, results)
+
+    def test_a_misconfigured_connection_still_ingests(self):
+        # Configuration-drift detection is report-only: a stored value the
+        # admin form would now reject must never prevent or alter a run
+        plugin = make_test_plugin()
+        connection = NetworkConnectionFactory(plugin_processing_interval=0)
+
+        link = StationLink.objects.create(
+            network_connection=connection, station=StationFactory(), enabled=True,
+            use_connection_timezone=True, timezone_info="UTC"
+        )
+        param_temp = DataParameterFactory(name="air_temperature", unit=CelsiusUnitFactory())
+        link.get_variable_mappings = lambda: [make_mapping(param_temp, KelvinUnitFactory())]
+
+        plugin.records = [
+            {"observation_time": datetime(2025, 1, 1, 0, 0, tzinfo=py_tz.utc), "temp_K": 293.15}
+        ]
+
+        results = plugin.run_process(connection)
+
+        self.assertIn(link.station.id, results)

--- a/adl/src/adl/monitoring/health.py
+++ b/adl/src/adl/monitoring/health.py
@@ -25,7 +25,7 @@ from datetime import datetime, timedelta
 from typing import Optional, Tuple
 
 from django.core.cache import cache
-from django.core.exceptions import ValidationError
+from django.core.exceptions import NON_FIELD_ERRORS, ValidationError
 from django.db.models import Count, Max, Q
 from django.urls import reverse
 from django.utils import timezone as dj_timezone
@@ -127,25 +127,68 @@ class Evidence:
     at: datetime
 
 
-def station_link_drifted(station_link) -> bool:
+@dataclass(frozen=True)
+class ConfigurationDrift:
     """
-    Whether a stored station link no longer passes its own validation
-    rules — ``full_clean()`` and nothing more, so every rule a plugin adds
-    to ``clean()`` improves this check retroactively.
+    Outcome of re-running a stored row's own validation.
 
-    Only ``ValidationError`` means drift: a crash in a validator is not
-    evidence the configuration is wrong, and unhandled it would blind the
-    diagnostic from one bad plugin.
+    ``drifted`` is the claim; ``evaluated`` is whether the claim could be
+    made at all — a crashed validator leaves ``evaluated`` False and
+    ``drifted`` False, because a crash is not evidence the configuration
+    is wrong. ``fields`` and ``messages`` come straight from
+    ``ValidationError.message_dict``: the field name is what the operator
+    needs to go and fix.
+    """
+
+    drifted: bool
+    evaluated: bool
+    fields: Tuple[str, ...] = ()
+    messages: Tuple[str, ...] = ()
+
+
+def configuration_drift(instance) -> ConfigurationDrift:
+    """
+    Whether a stored row no longer passes its own validation rules —
+    ``full_clean(validate_unique=False)`` and nothing more, so every rule a
+    plugin adds to ``clean()`` improves this check retroactively, and a
+    uniqueness collision (which cannot exist in a stored row) is never
+    re-litigated.
+
+    Only ``ValidationError`` means drift. Any other exception is caught and
+    makes no drift claim: a crash in a validator is not evidence the
+    configuration is wrong, and unhandled it would blind the diagnostic
+    from one bad plugin.
     """
     try:
-        station_link.full_clean(validate_unique=False)
-    except ValidationError:
-        return True
+        instance.full_clean(validate_unique=False)
+    except ValidationError as error:
+        message_dict = getattr(error, "message_dict", {NON_FIELD_ERRORS: [str(error)]})
+        fields = tuple(sorted(message_dict))
+        messages = tuple(
+            "%s: %s" % (field, " ".join(field_messages))
+            for field, field_messages in sorted(message_dict.items())
+        )
+        return ConfigurationDrift(drifted=True, evaluated=True,
+                                  fields=fields, messages=messages)
     except Exception:
-        logger.exception("[HEALTH] full_clean crashed for station link %s",
-                         station_link.id)
-        return False
-    return False
+        logger.exception("[HEALTH] full_clean crashed for %s %s",
+                         type(instance).__name__, getattr(instance, "id", None))
+        return ConfigurationDrift(drifted=False, evaluated=False)
+    return ConfigurationDrift(drifted=False, evaluated=True)
+
+
+def station_link_drifted(station_link) -> bool:
+    """Whether a stored station link's configuration has drifted — the
+    station-scope predicate layer-5 evidence filters on."""
+    return configuration_drift(station_link).drifted
+
+
+def connection_declares_validation_rules(connection) -> bool:
+    """True when the plugin's ``NetworkConnection`` subclass overrides
+    ``clean()`` — the no-I/O implemented-ness seam, mirroring
+    ``source_probe_supported``. A plugin that declares no rules must report
+    ``UNSUPPORTED``, never clean: silence is not validation."""
+    return type(connection).clean is not NetworkConnection.clean
 
 
 def probe_age_minutes(now, at):
@@ -232,14 +275,33 @@ def evaluate_connection_health(connection, queue_health=None, queue_health_provi
             checks=_all_skipped(_ladder_plan(), _("The connection is disabled.")),
         )
 
-    precondition = (HealthCheck(
+    enabled_check = HealthCheck(
         id="connection_enabled",
         layer=None,
         label=_("Connection enabled"),
         state=CheckState.OK,
         message=_("The connection is enabled and scheduled every %(interval)s minutes.")
                 % {"interval": connection.interval},
-    ),)
+    )
+
+    drift = configuration_drift(connection)
+    precondition = (enabled_check, _configuration_precondition(connection, drift))
+
+    if drift.drifted:
+        # Connection-scope drift short-circuits every layer below — the
+        # operator is sent to a field on their own form, never to the
+        # partner's server. Report-only: ingestion itself still runs.
+        return ConnectionHealthChecklist(
+            status=CheckState.MISCONFIGURED,
+            first_failing_layer=None,
+            headline_check_id="configuration_valid",
+            headline_message=_("The stored configuration is no longer valid — "
+                               "check field(s): %(fields)s.")
+                             % {"fields": ", ".join(drift.fields)},
+            precondition=precondition,
+            checks=_all_skipped(_ladder_plan(),
+                                _("the stored configuration is invalid.")),
+        )
 
     if queue_health is not None:
         provider = lambda: queue_health  # noqa: E731
@@ -277,6 +339,57 @@ def _headline(checks):
         if check.blocking and check.state == CheckState.WARNING:
             return CheckState.WARNING, check.layer, check
     return CheckState.OK, None, None
+
+
+def _configuration_precondition(connection, drift):
+    """
+    The configuration row of the precondition band, from an already-computed
+    :class:`ConfigurationDrift`. ``MISCONFIGURED`` is the only blocking
+    outcome; the two ``UNSUPPORTED`` shapes (no rules declared, validator
+    crashed) are epistemic and advisory.
+    """
+    label = _("Configuration valid")
+    if drift.drifted:
+        return HealthCheck(
+            id="configuration_valid",
+            layer=None,
+            label=label,
+            state=CheckState.MISCONFIGURED,
+            message=_("The stored configuration no longer passes validation — "
+                      "%(details)s. Fix the named field(s) on the connection's "
+                      "edit form. Nothing below is evaluated; ingestion itself "
+                      "is not stopped by this finding.")
+                    % {"details": "; ".join(drift.messages)},
+        )
+    if not drift.evaluated:
+        return HealthCheck(
+            id="configuration_valid",
+            layer=None,
+            label=label,
+            state=CheckState.UNSUPPORTED,
+            message=_("The plugin's validation rules crashed, so configuration "
+                      "drift could not be evaluated. This is not evidence the "
+                      "configuration is wrong; see the application logs."),
+            blocking=False,
+        )
+    if not connection_declares_validation_rules(connection):
+        return HealthCheck(
+            id="configuration_valid",
+            layer=None,
+            label=label,
+            state=CheckState.UNSUPPORTED,
+            message=_("This plugin declares no configuration rules of its own, "
+                      "so only core's field validation ran — silence is not "
+                      "validation."),
+            blocking=False,
+        )
+    return HealthCheck(
+        id="configuration_valid",
+        layer=None,
+        label=label,
+        state=CheckState.OK,
+        message=_("The stored configuration passes the plugin's validation rules."),
+    )
 
 
 def _ladder_plan():

--- a/adl/src/adl/monitoring/health.py
+++ b/adl/src/adl/monitoring/health.py
@@ -348,47 +348,39 @@ def _configuration_precondition(connection, drift):
     outcome; the two ``UNSUPPORTED`` shapes (no rules declared, validator
     crashed) are epistemic and advisory.
     """
-    label = _("Configuration valid")
+    def row(state, message, blocking=True):
+        return HealthCheck(id="configuration_valid", layer=None,
+                           label=_("Configuration valid"), state=state,
+                           message=message, blocking=blocking)
+
     if drift.drifted:
-        return HealthCheck(
-            id="configuration_valid",
-            layer=None,
-            label=label,
-            state=CheckState.MISCONFIGURED,
-            message=_("The stored configuration no longer passes validation — "
-                      "%(details)s. Fix the named field(s) on the connection's "
-                      "edit form. Nothing below is evaluated; ingestion itself "
-                      "is not stopped by this finding.")
-                    % {"details": "; ".join(drift.messages)},
+        return row(
+            CheckState.MISCONFIGURED,
+            _("The stored configuration no longer passes validation — "
+              "%(details)s. Fix the named field(s) on the connection's "
+              "edit form. Nothing below is evaluated; ingestion itself "
+              "is not stopped by this finding.")
+            % {"details": "; ".join(drift.messages)},
         )
     if not drift.evaluated:
-        return HealthCheck(
-            id="configuration_valid",
-            layer=None,
-            label=label,
-            state=CheckState.UNSUPPORTED,
-            message=_("The plugin's validation rules crashed, so configuration "
-                      "drift could not be evaluated. This is not evidence the "
-                      "configuration is wrong; see the application logs."),
+        return row(
+            CheckState.UNSUPPORTED,
+            _("The plugin's validation rules crashed, so configuration "
+              "drift could not be evaluated. This is not evidence the "
+              "configuration is wrong; see the application logs."),
             blocking=False,
         )
     if not connection_declares_validation_rules(connection):
-        return HealthCheck(
-            id="configuration_valid",
-            layer=None,
-            label=label,
-            state=CheckState.UNSUPPORTED,
-            message=_("This plugin declares no configuration rules of its own, "
-                      "so only core's field validation ran — silence is not "
-                      "validation."),
+        return row(
+            CheckState.UNSUPPORTED,
+            _("This plugin declares no connection-level configuration rules "
+              "of its own, so only core's field validation ran — silence is "
+              "not validation."),
             blocking=False,
         )
-    return HealthCheck(
-        id="configuration_valid",
-        layer=None,
-        label=label,
-        state=CheckState.OK,
-        message=_("The stored configuration passes the plugin's validation rules."),
+    return row(
+        CheckState.OK,
+        _("The stored configuration passes the plugin's validation rules."),
     )
 
 

--- a/adl/src/adl/monitoring/templates/monitoring/station_link_monitoring.html
+++ b/adl/src/adl/monitoring/templates/monitoring/station_link_monitoring.html
@@ -21,6 +21,24 @@
 {% block main_content %}
     <div style="margin-top: 40px">
 
+        {% if configuration_drift %}
+            {# Station-scope drift is advisory: it renders here, beside this
+               station's timeline, and never changes the connection's verdict.
+               Runs from a drifted link are excluded from source-layer
+               evidence, so our own configuration fault is not attributed to
+               the partner. #}
+            <div class="help-block help-warning">
+                <p>
+                    {% trans "Configuration drift — this station link's stored configuration no longer passes validation. Fix the named field(s) on the station link's edit form. Ingestion is not stopped by this finding, but this station's runs are excluded from the connection's source-layer evidence." %}
+                </p>
+                <ul>
+                    {% for message in configuration_drift.messages %}
+                        <li>{{ message }}</li>
+                    {% endfor %}
+                </ul>
+            </div>
+        {% endif %}
+
         <table class="listing">
             <thead>
             <tr>

--- a/adl/src/adl/monitoring/tests/test_health.py
+++ b/adl/src/adl/monitoring/tests/test_health.py
@@ -35,6 +35,7 @@ from adl.monitoring.constants import (
     CheckState,
 )
 from adl.monitoring.health import (
+    configuration_drift,
     evaluate_connection_health,
     station_link_drifted,
     store_connection_health,
@@ -858,6 +859,141 @@ class StationLinkDriftedTests(TestCase):
                 raise RuntimeError("boom")
 
         self.assertFalse(station_link_drifted(ExplodingLink()))
+
+    def test_drift_names_the_offending_fields_from_message_dict(self):
+        from adl.core.models import StationLink
+
+        drift = configuration_drift(StationLink())
+
+        self.assertTrue(drift.drifted)
+        self.assertTrue(drift.evaluated)
+        self.assertIn("station", drift.fields)
+        self.assertTrue(any("station" in message for message in drift.messages))
+
+
+class ConnectionConfigurationDriftTests(HealthEvaluatorTestCase):
+    """Connection-scope drift: full_clean(validate_unique=False) and nothing
+    more. A drifted connection is MISCONFIGURED in the precondition band and
+    short-circuits every layer below; DISABLED still outranks it; a plugin
+    with no clean() override reports UNSUPPORTED, never clean."""
+
+    def configuration_check(self, checklist):
+        matches = [c for c in checklist.precondition if c.id == "configuration_valid"]
+        self.assertEqual(len(matches), 1)
+        return matches[0]
+
+    def test_misconfigured_connection_short_circuits_the_ladder(self):
+        self.make_healthy()
+        # A stored value the admin form would now reject: below the
+        # MinValueValidator(1) bound on the interval
+        self.connection.plugin_processing_interval = 0
+
+        checklist = self.evaluate()
+
+        self.assertEqual(checklist.status, CheckState.MISCONFIGURED)
+        self.assertIsNone(checklist.first_failing_layer)
+        self.assertEqual(checklist.headline_check_id, "configuration_valid")
+        self.assertIn("plugin_processing_interval", checklist.headline_message)
+        for check in checklist.checks:
+            self.assertEqual(check.state, CheckState.SKIPPED, check.id)
+
+    def test_misconfigured_row_names_the_field_in_the_precondition_band(self):
+        self.make_healthy()
+        self.connection.plugin_processing_interval = 0
+
+        check = self.configuration_check(self.evaluate())
+
+        self.assertEqual(check.state, CheckState.MISCONFIGURED)
+        self.assertIn("plugin_processing_interval", check.message)
+
+    def test_misconfigured_connection_never_dials_the_broker(self):
+        self.make_healthy()
+        self.connection.plugin_processing_interval = 0
+
+        with patch("adl.monitoring.health.get_ingestion_queue_health") as mock_broker:
+            evaluate_connection_health(self.connection)
+
+        mock_broker.assert_not_called()
+
+    def test_disabled_outranks_misconfigured(self):
+        self.connection.plugin_processing_enabled = False
+        self.connection.plugin_processing_interval = 0
+
+        checklist = self.evaluate()
+
+        self.assertEqual(checklist.status, CheckState.DISABLED)
+        self.assertEqual(len(checklist.precondition), 1)
+
+    def test_plugin_without_clean_override_reports_unsupported_not_clean(self):
+        self.make_healthy()
+
+        checklist = self.evaluate()
+
+        check = self.configuration_check(checklist)
+        # Silence must not read as validation — but it is advisory, so the
+        # connection's verdict is untouched
+        self.assertEqual(check.state, CheckState.UNSUPPORTED)
+        self.assertFalse(check.blocking)
+        self.assertEqual(checklist.status, CheckState.OK)
+
+    def test_plugin_with_a_passing_clean_override_reports_ok(self):
+        self.make_healthy()
+
+        with patch("adl.monitoring.health.connection_declares_validation_rules",
+                   return_value=True):
+            check = self.configuration_check(self.evaluate())
+
+        self.assertEqual(check.state, CheckState.OK)
+
+    def test_a_crashing_validator_makes_no_drift_claim(self):
+        from adl.core.models import NetworkConnection
+
+        self.make_healthy()
+
+        with patch.object(NetworkConnection, "full_clean",
+                          side_effect=RuntimeError("boom")):
+            checklist = self.evaluate()
+
+        check = self.configuration_check(checklist)
+        self.assertEqual(check.state, CheckState.UNSUPPORTED)
+        self.assertFalse(check.blocking)
+        # Not evidence of drift: the ladder is still evaluated and the
+        # connection's verdict is whatever the ladder says
+        self.assertEqual(checklist.status, CheckState.OK)
+
+    def test_every_offending_field_is_named(self):
+        # Ordinary field validation catches drift with no clean() override
+        # needed — and a multi-field drift names each field
+        self.make_healthy()
+        self.connection.plugin_processing_interval = 0
+        self.connection.ingest_timeout_seconds = 5
+
+        checklist = self.evaluate()
+
+        self.assertEqual(checklist.status, CheckState.MISCONFIGURED)
+        self.assertIn("plugin_processing_interval", checklist.headline_message)
+        self.assertIn("ingest_timeout_seconds", checklist.headline_message)
+
+    def test_one_drifted_station_link_does_not_turn_a_healthy_connection_red(self):
+        self.make_healthy()
+
+        with patch("adl.monitoring.health.station_link_drifted", return_value=True):
+            checklist = self.evaluate()
+
+        self.assertEqual(checklist.status, CheckState.OK)
+        self.assertNotEqual(checklist.status, CheckState.MISCONFIGURED)
+
+    def test_misconfigured_verdict_is_stored_with_null_layer(self):
+        self.make_healthy()
+        self.connection.plugin_processing_interval = 0
+
+        checklist = self.evaluate()
+        health = store_connection_health(self.connection, checklist)
+
+        self.assertEqual(health.status, CheckState.MISCONFIGURED)
+        self.assertIsNone(health.first_failing_layer)
+        transition = NetworkConnectionHealthTransition.objects.get()
+        self.assertEqual(transition.to_status, CheckState.MISCONFIGURED)
 
 
 class StoredVerdictTests(HealthEvaluatorTestCase):

--- a/adl/src/adl/monitoring/tests/test_health_view.py
+++ b/adl/src/adl/monitoring/tests/test_health_view.py
@@ -87,3 +87,43 @@ class ConnectionsListingLinkTests(HealthPageTestCase):
         buttons = get_connection_list_more_buttons(self.connection)
 
         self.assertIn(self.url, [button.url for button in buttons])
+
+
+class StationLinkDriftBannerTests(HealthPageTestCase):
+    """Station-scope drift is advisory: it renders on the station link's own
+    monitoring page and nowhere near the connection's headline."""
+
+    def setUp(self):
+        super().setUp()
+        self.station_page_url = reverse("station_link_monitoring", args=[self.link.id])
+
+    def test_a_valid_link_shows_no_drift_banner(self):
+        response = self.client.get(self.station_page_url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "Configuration drift")
+
+    def test_a_drifted_link_names_the_field_on_its_own_page(self):
+        from unittest.mock import patch
+
+        from adl.monitoring.health import ConfigurationDrift
+
+        drift = ConfigurationDrift(
+            drifted=True, evaluated=True,
+            fields=("timezone_info",),
+            messages=("timezone_info: This field cannot be blank.",),
+        )
+        with patch("adl.monitoring.views.configuration_drift", return_value=drift):
+            response = self.client.get(self.station_page_url)
+
+        self.assertContains(response, "Configuration drift")
+        self.assertContains(response, "timezone_info")
+
+    def test_the_misconfigured_precondition_row_renders_on_the_diagnostic_page(self):
+        self.connection.plugin_processing_interval = 0
+        self.connection.save()
+
+        response = self.client.get(self.url)
+
+        self.assertContains(response, "MISCONFIGURED")
+        self.assertContains(response, "plugin_processing_interval")

--- a/adl/src/adl/monitoring/views/__init__.py
+++ b/adl/src/adl/monitoring/views/__init__.py
@@ -16,6 +16,7 @@ from wagtail.admin.paginator import WagtailPaginator
 from adl.core.models import NetworkConnection, DispatchChannel, StationLink
 from adl.core.utils import get_object_or_none
 from ..constants import NETWORK_PLUGIN_TASK_NAME
+from ..health import configuration_drift
 from ..models import StationLinkActivityLog
 from ..serializers import TaskResultSerializer, StationLinkActivityLogSerializer
 
@@ -274,13 +275,18 @@ def station_link_monitoring(request, link_id):
     page_obj = paginator.get_page(page_number)
     elided_page_range = paginator.get_elided_page_range(page_number)
     
+    # Station-scope configuration drift is advisory: it renders here, beside
+    # this station's own timeline, and never touches the connection's verdict
+    drift = configuration_drift(link)
+
     context = {
         "breadcrumbs_items": breadcrumbs_items,
         "page_obj": page_obj,
         "paginator": paginator,
         "elided_page_range": elided_page_range,
         "direction": direction,
-        "station_link": link
+        "station_link": link,
+        "configuration_drift": drift if drift.drifted else None,
     }
     return render(request, "monitoring/station_link_monitoring.html", context)
 

--- a/docs/developer_guide/plugins/plugin_implementation.md
+++ b/docs/developer_guide/plugins/plugin_implementation.md
@@ -153,6 +153,27 @@ you omit it, station links will not appear in the admin and data collection
 will silently do nothing.
 ```
 
+#### Validation rules: `clean()` must not perform I/O
+
+Any `clean()` override you add to your `NetworkConnection` or `StationLink`
+subclass does double duty. Besides validating the admin form at save time, the
+ingestion diagnostic re-runs `full_clean()` against **stored** rows to detect
+configuration drift — a row that was valid when written but no longer passes
+today's rules. Every rule you add improves both the form and the diagnostic in
+one edit, retroactively, with no new contract to implement.
+
+Because of this, `clean()` is called **outside the request cycle** (from the
+periodic health sweep and the diagnostic page). It must therefore be a pure
+check over the model's own fields:
+
+- **No I/O** — never open a network connection, hit the source's API, touch
+  the filesystem, or perform slow queries inside `clean()`.
+- Raise `django.core.exceptions.ValidationError` keyed by field name — the
+  diagnostic reports exactly those field names to the operator.
+- Drift detection is **report-only**: a failing `clean()` never stops or
+  alters an ingestion run. A plugin with no `clean()` override is reported as
+  declaring no configuration rules (`UNSUPPORTED`), not as validated.
+
 ### 4.2 `StationLink` Subclass
 
 Subclass `adl.core.models.StationLink` to store per-station configuration —


### PR DESCRIPTION
Closes #183. Part of the ingestion diagnostic spec #171 (decision section 10).

## What this adds

- **Connection-scope drift** is detected by `full_clean(validate_unique=False)` and nothing more. A `ValidationError` puts a `MISCONFIGURED` row in the precondition band, names the offending field(s) from `message_dict`, seizes the headline, and short-circuits every ladder layer to `SKIPPED`. `DISABLED` still outranks it (evaluated first).
- **Only `ValidationError` means drift.** Any other exception from a validator is caught per connection, logged, and produces no drift claim — the row reports `UNSUPPORTED` ("could not be evaluated"), advisory.
- **Silence is not validation.** A plugin whose `NetworkConnection` subclass has no `clean()` override reports `UNSUPPORTED`, never clean (`connection_declares_validation_rules`, the same no-I/O implemented-ness seam as `source_probe_supported`).
- **Report-only.** Nothing in the ingestion path changed; a new runner test proves a misconfigured connection still ingests.
- **Station-scope drift stays advisory**: it renders as a warning banner on the station link's own monitoring page, naming the fields, and never touches the connection's headline. The layer-5 evidence exclusion (`drifted_link_ids`) landed with #181; `station_link_drifted` is now backed by the shared `configuration_drift` seam.
- The plugin authoring guide records that `clean()` must not perform I/O (it now runs outside the request cycle).

## Tests

`ConnectionConfigurationDriftTests` at the evaluator seam cover each acceptance criterion; `StationLinkDriftBannerTests` cover the two pages; a runner test covers report-only. Full suite: 315 passing.