### PR TITLE
Station-scope source check on the station-link inspect page

### DIFF
--- a/adl/src/adl/core/components.py
+++ b/adl/src/adl/core/components.py
@@ -3,6 +3,7 @@ from django.urls import reverse
 from django.utils import timezone as dj_timezone
 from wagtail.admin.ui.components import Component
 
+from adl.core.source_checks import CHECK_STATION_SOURCE
 from adl.monitoring.health import configuration_drift, probe_age_minutes
 from adl.monitoring.models import SourceProbeResult, StationLinkActivityLog
 
@@ -64,8 +65,12 @@ class StationLinkSourceCheckPanel(Component):
         station_link = parent_context.get('station_link')
         request = parent_context.get('request')
 
+        # Filtered on the check id as well as the FK, so only a
+        # station-scope check's own row can ever be presented as this
+        # station's answer — by construction, not by convention
         latest = (SourceProbeResult.objects
-                  .filter(station_link=station_link)
+                  .filter(station_link=station_link,
+                          check_id=CHECK_STATION_SOURCE)
                   .order_by('-at')
                   .first())
         if latest is not None:

--- a/adl/src/adl/core/components.py
+++ b/adl/src/adl/core/components.py
@@ -1,7 +1,10 @@
 from django.middleware.csrf import get_token
+from django.urls import reverse
+from django.utils import timezone as dj_timezone
 from wagtail.admin.ui.components import Component
 
-from adl.monitoring.models import StationLinkActivityLog
+from adl.monitoring.health import configuration_drift, probe_age_minutes
+from adl.monitoring.models import SourceProbeResult, StationLinkActivityLog
 
 
 class StationLinkCollectionStatusPanel(Component):
@@ -35,4 +38,54 @@ class StationLinkCollectionStatusPanel(Component):
             context['request'] = parent_context['request']
             context['csrf_token'] = get_token(parent_context['request'])
         
+        return context
+
+
+class StationLinkSourceCheckPanel(Component):
+    """
+    The station-scope source check on the station-link inspect page: the
+    on-demand check button, this station's own latest stored result, and
+    the advisory configuration-drift notice.
+
+    The button is hidden, not disabled, when the user lacks the probe
+    permission or the plugin does not implement the contract. Only rows
+    carrying this station link's FK are shown — a connection-scope probe
+    result is never presented as this station's answer.
+    """
+
+    template_name = 'core/panels/sl_source_check.html'
+
+    def get_context_data(self, parent_context):
+        # Imported here, not at module level: the views module imports core
+        # models and utils, which import back into this app at startup
+        from adl.monitoring.views.health import PROBE_PERMISSION
+
+        context = super().get_context_data(parent_context)
+        station_link = parent_context.get('station_link')
+        request = parent_context.get('request')
+
+        latest = (SourceProbeResult.objects
+                  .filter(station_link=station_link)
+                  .order_by('-at')
+                  .first())
+        if latest is not None:
+            latest.age_minutes = probe_age_minutes(dj_timezone.now(), latest.at)
+
+        drift = configuration_drift(station_link)
+
+        context['station_link'] = station_link
+        context['latest_result'] = latest
+        context['configuration_drift'] = drift if drift.drifted else None
+        context['show_check_button'] = (
+            request is not None
+            and request.user.has_perm(PROBE_PERMISSION)
+            and station_link.station_source_check_supported
+        )
+        context['check_source_url'] = reverse('station_link_check_source',
+                                              args=[station_link.id])
+
+        if request is not None:
+            context['request'] = request
+            context['csrf_token'] = get_token(request)
+
         return context

--- a/adl/src/adl/core/models.py
+++ b/adl/src/adl/core/models.py
@@ -753,6 +753,35 @@ class StationLink(PolymorphicModel, ClusterableModel):
     
     def get_extra_model_admin_buttons(self, classname=None):
         return []
+
+    def check_station_source(self):
+        """
+        Ask whether the source offers data for **this** station link
+        (layer 5 of the ingestion diagnostic, station-scoped). Strictly
+        **read-only**, run **on demand only**, one station at a time.
+
+        Deliberately a distinct method rather than a parameterised
+        ``check_source()``: ``UNSUPPORTED`` must be independently
+        answerable, or the one-line opt-in dies for the other plugins.
+        Zero matches is ``OK`` — a date-structured directory is
+        legitimately empty at every rollover — with the resolved path and
+        the match count in the message, so the operator sees a typo rather
+        than infers one. The return is normalised by core and never
+        trusted as-is.
+        """
+        from adl.core.source_checks import SourceCheckResult, SourceCheckStatus
+        return SourceCheckResult(
+            status=SourceCheckStatus.UNSUPPORTED,
+            message=_("This plugin does not implement the station source check."),
+        )
+
+    @property
+    def station_source_check_supported(self):
+        """True when this station link's plugin implements the station-scope
+        source check — what decides whether the check button exists at all,
+        without performing any I/O."""
+        from adl.core.source_checks import station_link_implements_check_station_source
+        return station_link_implements_check_station_source(self)
     
     def fetch_latest_data(self):
         """

--- a/adl/src/adl/core/source_checks.py
+++ b/adl/src/adl/core/source_checks.py
@@ -36,11 +36,15 @@ logger = logging.getLogger(__name__)
 # plugin's own source check together
 PROBE_WALL_CLOCK_SECONDS = 15
 
-# Stable identifiers for the three probe steps — these become stored
+# Stable identifiers for the probe steps — these become stored
 # `SourceProbeResult.check_id` values, so they must never be renamed
 CHECK_DNS = "dns_resolution"
 CHECK_TCP = "tcp_connect"
 CHECK_SOURCE = "source_check"
+# The station-scope check is its own stored identifier, not a reuse of
+# `source_check`: the evaluator's connection-scope filter and the stored
+# history both stay unambiguous
+CHECK_STATION_SOURCE = "station_source_check"
 
 
 class SourceCheckStatus:
@@ -113,6 +117,16 @@ def connection_implements_check_source(connection) -> bool:
     distinguish "not recently checked" from "not checkable at all"."""
     from adl.core.models import NetworkConnection
     return type(connection).check_source is not NetworkConnection.check_source
+
+
+def station_link_implements_check_station_source(station_link) -> bool:
+    """True when the station link's plugin overrides
+    ``check_station_source()``. Deliberately independent of the
+    connection-scope contract: a plugin implementing ``check_source()`` has
+    said nothing about the station-scope check, so ``UNSUPPORTED`` stays
+    independently answerable."""
+    from adl.core.models import StationLink
+    return type(station_link).check_station_source is not StationLink.check_station_source
 
 
 def _elapsed_ms(started: float) -> int:
@@ -248,21 +262,30 @@ def _tcp_step(executor, host, port, deadline) -> ProbeStep:
 
 
 def _source_step(connection, executor, deadline, timeout_seconds) -> ProbeStep:
+    return _plugin_check_step(
+        CHECK_SOURCE, connection.check_source, executor, deadline, timeout_seconds,
+        log_context="connection %s" % connection.id,
+    )
+
+
+def _plugin_check_step(check_id, check, executor, deadline, timeout_seconds,
+                       log_context) -> ProbeStep:
+    """Run one plugin-implemented layer-5 check under the wall-clock bound
+    and pass its return through the normaliser — shared by the connection
+    probe's source step and the station-scope check."""
     started = time.monotonic()
     try:
-        raw = _bounded_call(executor, connection.check_source,
-                            deadline - time.monotonic())
+        raw = _bounded_call(executor, check, deadline - time.monotonic())
     except FutureTimeoutError:
-        return ProbeStep(CHECK_SOURCE, 5, SourceCheckResult(
+        return ProbeStep(check_id, 5, SourceCheckResult(
             status=SourceCheckStatus.FAILED,
             message=_("The source check did not complete within the probe's "
                       "%(seconds)s-second budget.") % {"seconds": timeout_seconds},
             latency_ms=_elapsed_ms(started),
         ))
     except Exception as e:
-        logger.exception("[SOURCE PROBE] check_source raised for connection %s",
-                         connection.id)
-        return ProbeStep(CHECK_SOURCE, 5, SourceCheckResult(
+        logger.exception("[SOURCE PROBE] %s raised for %s", check_id, log_context)
+        return ProbeStep(check_id, 5, SourceCheckResult(
             status=SourceCheckStatus.FAILED,
             message=_("The source check raised %(type)s: %(error)s")
                     % {"type": type(e).__name__, "error": e},
@@ -272,4 +295,31 @@ def _source_step(connection, executor, deadline, timeout_seconds) -> ProbeStep:
     result = normalise_source_check_result(raw)
     if result.latency_ms is None and result.status != SourceCheckStatus.UNSUPPORTED:
         result = replace(result, latency_ms=_elapsed_ms(started))
-    return ProbeStep(CHECK_SOURCE, 5, result)
+    return ProbeStep(check_id, 5, result)
+
+
+def run_station_source_check(station_link,
+                             timeout_seconds=PROBE_WALL_CLOCK_SECONDS) -> ProbeStep:
+    """
+    Run one station link's ``check_station_source()`` on demand: a single
+    step, one station at a time, with no fan-out anywhere — a burst of
+    failed authentications is what actually trips a ban.
+
+    No DNS or TCP step is run here; the connection-scope probe owns the
+    network path. The plugin's return passes through the same normaliser as
+    the probe, under the same wall-clock bound.
+    """
+    deadline = time.monotonic() + timeout_seconds
+
+    # Not a context manager, for the same reason as run_source_probe: `with`
+    # would join an abandoned worker on exit, letting a stuck plugin call
+    # outlive the wall-clock bound this function promises
+    executor = ThreadPoolExecutor(max_workers=1)
+    try:
+        return _plugin_check_step(
+            CHECK_STATION_SOURCE, station_link.check_station_source,
+            executor, deadline, timeout_seconds,
+            log_context="station link %s" % station_link.id,
+        )
+    finally:
+        executor.shutdown(wait=False)

--- a/adl/src/adl/core/templates/core/panels/sl_source_check.html
+++ b/adl/src/adl/core/templates/core/panels/sl_source_check.html
@@ -1,0 +1,72 @@
+{% load wagtailadmin_tags i18n %}
+
+{# Status badges are styled by the shared stylesheet (adl/css/status_badges.css), loaded admin-wide by the insert_global_admin_css hook #}
+<div class="collection-status">
+    <div class="collection-status__header">
+        <h3 class="collection-status__title">{% trans "Station Source Check" %}</h3>
+    </div>
+
+    {% if configuration_drift %}
+        {% comment %}Station-scope drift is advisory: it renders here, beside
+        this station's own status, and never changes the connection's
+        verdict.{% endcomment %}
+        <div class="help-block help-warning">
+            <p>
+                {% trans "Configuration drift — this station link's stored configuration no longer passes validation. Fix the named field(s) on the station link's edit form. Ingestion is not stopped by this finding, but this station's runs are excluded from the connection's source-layer evidence." %}
+            </p>
+            <ul>
+                {% for message in configuration_drift.messages %}
+                    <li>{{ message }}</li>
+                {% endfor %}
+            </ul>
+        </div>
+    {% endif %}
+
+    {% if latest_result %}
+        <div class="status-card {% if latest_result.status == 'OK' %}status-card--success{% elif latest_result.status == 'FAILED' %}status-card--error{% endif %}">
+            <div class="status-card__grid">
+                <div class="status-card__item">
+                    <span class="status-card__label">{% trans "Status" %}</span>
+                    <span class="status-card__value">
+                        <span class="status-badge {% if latest_result.status == 'OK' %}status-badge--success{% elif latest_result.status == 'FAILED' %}status-badge--error{% endif %}">
+                            {{ latest_result.status }}
+                        </span>
+                    </span>
+                </div>
+                <div class="status-card__item">
+                    <span class="status-card__label">{% trans "Checked" %}</span>
+                    <span class="status-card__value">
+                        {% blocktrans with minutes=latest_result.age_minutes %}{{ minutes }} minute(s) ago{% endblocktrans %}
+                    </span>
+                </div>
+                {% if latest_result.latency_ms %}
+                    <div class="status-card__item">
+                        <span class="status-card__label">{% trans "Latency" %}</span>
+                        <span class="status-card__value">{{ latest_result.latency_ms }} ms</span>
+                    </div>
+                {% endif %}
+            </div>
+            {% if latest_result.message %}
+                <div class="status-card__item" style="margin-top: 0.5rem;">
+                    <span class="status-card__value">{{ latest_result.message }}</span>
+                </div>
+            {% endif %}
+        </div>
+    {% else %}
+        <p class="help-block help-info">
+            {% trans "This station's source configuration has not been checked yet." %}
+        </p>
+    {% endif %}
+
+    {% if show_check_button %}
+        {% comment %}One station at a time, on demand only — a press inside
+        the 60-second cooldown returns the stored result, never an
+        error{% endcomment %}
+        <form method="post" action="{{ check_source_url }}">
+            {% csrf_token %}
+            <button type="submit" class="button button-small">
+                {% trans "Check station source now" %}
+            </button>
+        </form>
+    {% endif %}
+</div>

--- a/adl/src/adl/core/templates/core/panels/sl_source_check.html
+++ b/adl/src/adl/core/templates/core/panels/sl_source_check.html
@@ -47,8 +47,8 @@
                 {% endif %}
             </div>
             {% if latest_result.message %}
-                <div class="status-card__item" style="margin-top: 0.5rem;">
-                    <span class="status-card__value">{{ latest_result.message }}</span>
+                <div class="{% if latest_result.status == 'FAILED' %}status-card__error{% else %}status-card__message{% endif %}">
+                    {{ latest_result.message }}
                 </div>
             {% endif %}
         </div>

--- a/adl/src/adl/core/templates/core/station_link_inspect.html
+++ b/adl/src/adl/core/templates/core/station_link_inspect.html
@@ -65,6 +65,10 @@
         {% component collection_status_panel with station_link=object %}
     {% endif %}
 
+    {% if source_check_panel %}
+        {% component source_check_panel with station_link=object %}
+    {% endif %}
+
     {% block fields_output %}
         {% if fields %}
             <div class="inspect-fields">

--- a/adl/src/adl/core/tests/test_source_checks.py
+++ b/adl/src/adl/core/tests/test_source_checks.py
@@ -15,13 +15,16 @@ from django.test import TestCase
 from adl.core.source_checks import (
     CHECK_DNS,
     CHECK_SOURCE,
+    CHECK_STATION_SOURCE,
     CHECK_TCP,
     SourceCheckResult,
     SourceCheckStatus,
     normalise_source_check_result,
     run_source_probe,
+    run_station_source_check,
+    station_link_implements_check_station_source,
 )
-from adl.core.tests.factories import NetworkConnectionFactory
+from adl.core.tests.factories import NetworkConnectionFactory, StationLinkFactory
 
 
 class BaseContractDefaultTests(TestCase):
@@ -210,3 +213,102 @@ class ProbeOrchestrationTests(ProbeTestCase):
 
         self.assertEqual(steps[CHECK_SOURCE].result.status, SourceCheckStatus.FAILED)
         self.assertIn("did not complete", steps[CHECK_SOURCE].result.message)
+
+
+class StationCheckContractTests(TestCase):
+    """The station-scope contract is a distinct method, not a parameterised
+    check_source: UNSUPPORTED must be independently answerable, or the
+    one-line opt-in dies for the other 20 plugins."""
+
+    def setUp(self):
+        self.link = StationLinkFactory()
+
+    def test_base_check_station_source_reports_unsupported(self):
+        result = self.link.check_station_source()
+
+        self.assertEqual(result.status, SourceCheckStatus.UNSUPPORTED)
+
+    def test_base_station_link_does_not_support_the_check(self):
+        self.assertFalse(self.link.station_source_check_supported)
+
+    def test_connection_scope_check_source_does_not_answer_for_the_station(self):
+        # A plugin implementing the connection-scope contract has said
+        # nothing about the station-scope one
+        self.link.network_connection.check_source = lambda: SourceCheckResult(
+            status=SourceCheckStatus.OK)
+
+        self.assertFalse(
+            station_link_implements_check_station_source(self.link))
+
+    def test_an_overriding_subclass_supports_the_check(self):
+        class _ImplementingLink:
+            def check_station_source(self):
+                return SourceCheckResult(status=SourceCheckStatus.OK)
+
+        self.assertTrue(
+            station_link_implements_check_station_source(_ImplementingLink()))
+
+
+class StationCheckRunTests(TestCase):
+    """run_station_source_check: one step, one station, no fan-out — the
+    plugin's return passes through the same normaliser as the probe."""
+
+    def setUp(self):
+        self.link = StationLinkFactory()
+
+    def run_check(self, **kwargs):
+        return run_station_source_check(self.link, **kwargs)
+
+    def test_zero_matches_is_ok_with_the_resolved_path_in_the_message(self):
+        # Date-structured directories are legitimately empty at every
+        # rollover; the operator reads the resolved path and match count
+        # and judges better than a rule can
+        self.link.check_station_source = lambda: SourceCheckResult(
+            status=SourceCheckStatus.OK,
+            message="Resolved /data/2026/07/31; 0 file(s) matched.",
+        )
+
+        step = self.run_check()
+
+        self.assertEqual(step.check_id, CHECK_STATION_SOURCE)
+        self.assertEqual(step.layer, 5)
+        self.assertEqual(step.result.status, SourceCheckStatus.OK)
+        self.assertIn("/data/2026/07/31", step.result.message)
+        self.assertIn("0 file(s) matched", step.result.message)
+
+    def test_base_station_link_reports_unsupported(self):
+        step = self.run_check()
+
+        self.assertEqual(step.result.status, SourceCheckStatus.UNSUPPORTED)
+
+    def test_malformed_return_degrades_to_malformed(self):
+        self.link.check_station_source = lambda: {"status": "OK"}
+
+        step = self.run_check()
+
+        self.assertEqual(step.result.status, SourceCheckStatus.MALFORMED)
+
+    def test_a_raising_check_reports_failed_not_a_crash(self):
+        def boom():
+            raise RuntimeError("listing exploded")
+
+        self.link.check_station_source = boom
+
+        step = self.run_check()
+
+        self.assertEqual(step.result.status, SourceCheckStatus.FAILED)
+        self.assertIn("listing exploded", step.result.message)
+
+    def test_check_is_bounded_by_wall_clock(self):
+        import time
+
+        def slow():
+            time.sleep(0.5)
+            return SourceCheckResult(status=SourceCheckStatus.OK)
+
+        self.link.check_station_source = slow
+
+        step = self.run_check(timeout_seconds=0.05)
+
+        self.assertEqual(step.result.status, SourceCheckStatus.FAILED)
+        self.assertIn("did not complete", step.result.message)

--- a/adl/src/adl/core/utils.py
+++ b/adl/src/adl/core/utils.py
@@ -394,6 +394,17 @@ def get_url_for_connection(connection, view_name, takes_args=False):
     return reverse(viewset.get_url_name(view_name))
 
 
+def get_url_for_station_link(station_link, view_name, takes_args=False):
+    from adl.core.models import StationLink
+    model_cls = get_child_model_by_name(StationLink, station_link._meta.model_name)
+    viewset = station_link_viewset_registry.get(model_cls._meta.model_name)
+
+    if takes_args:
+        return reverse(viewset.get_url_name(view_name), kwargs={"pk": station_link.pk})
+
+    return reverse(viewset.get_url_name(view_name))
+
+
 def get_url_for_dispatch_channel(dispatch_channel, view_name, takes_args=False):
     from adl.core.models import DispatchChannel
     model_cls = get_child_model_by_name(DispatchChannel, dispatch_channel._meta.model_name)

--- a/adl/src/adl/core/viewsets.py
+++ b/adl/src/adl/core/viewsets.py
@@ -7,7 +7,7 @@ from wagtail.admin.viewsets.chooser import ChooserViewSet
 from wagtail.admin.viewsets.model import ModelViewSet
 from wagtail.admin.widgets import HeaderButton
 
-from .components import StationLinkCollectionStatusPanel
+from .components import StationLinkCollectionStatusPanel, StationLinkSourceCheckPanel
 from .constants import PREDEFINED_DATA_PARAMETERS
 from .models import (
     Network,
@@ -203,6 +203,7 @@ class StationLinkInspectView(generic.InspectView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["collection_status_panel"] = StationLinkCollectionStatusPanel()
+        context["source_check_panel"] = StationLinkSourceCheckPanel()
         return context
 
 

--- a/adl/src/adl/monitoring/tests/test_health.py
+++ b/adl/src/adl/monitoring/tests/test_health.py
@@ -500,6 +500,21 @@ class SourceProbeLayerTests(ExternalLayerTestCase):
         self.assertEqual(self.check(checklist, "network_path").state, CheckState.STALE)
         self.assertEqual(checklist.status, CheckState.OK)
 
+    def test_station_scope_source_check_cannot_move_the_connection_verdict(self):
+        # The on-demand station check persists against the same model with
+        # its station-link FK set; a fresh FAILED station row must leave
+        # layer 5 at its resting STALE state, not seize the headline
+        self.make_healthy()
+        self.with_supported_contract()
+        self.probe_row("station_source_check", "FAILED", age=timedelta(minutes=1),
+                       layer="source", category="AUTH_FAILED",
+                       station_link=self.link)
+
+        checklist = self.evaluate()
+
+        self.assertEqual(self.check(checklist, "source_check").state, CheckState.STALE)
+        self.assertEqual(checklist.status, CheckState.OK)
+
     def test_malformed_probe_row_reports_unsupported_not_a_verdict(self):
         self.make_healthy()
         self.with_supported_contract()

--- a/adl/src/adl/monitoring/tests/test_station_source_check_view.py
+++ b/adl/src/adl/monitoring/tests/test_station_source_check_view.py
@@ -84,7 +84,7 @@ class StationCheckPermissionTests(StationCheckViewTestCase):
         self.assertEqual(xhr_response.status_code, 403)
 
 
-class StationCheckRunTests(StationCheckViewTestCase):
+class StationCheckPostTests(StationCheckViewTestCase):
     def test_zero_matches_reports_ok_with_the_resolved_path(self):
         with patch("adl.monitoring.views.health.run_station_source_check",
                    return_value=ZERO_MATCH_STEP):

--- a/adl/src/adl/monitoring/tests/test_station_source_check_view.py
+++ b/adl/src/adl/monitoring/tests/test_station_source_check_view.py
@@ -1,0 +1,286 @@
+"""
+Seam-3 tests for the station-scope source check: permission, cooldown
+keying and the zero-match ``OK`` are HTTP-level by construction — a 403
+versus a stored result versus a fresh run is not visible below the view.
+
+The check itself is substituted at its one seam
+(``adl.monitoring.views.health.run_station_source_check``); no test dials
+a host. Keying is the point under test: the cooldown is ``(host, station
+link)``, so one station's press must never answer for another's.
+"""
+
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
+from django.core.cache import cache
+from django.test import RequestFactory, TestCase
+from django.urls import reverse
+from django.utils import timezone as dj_tz
+
+from adl.core.components import StationLinkSourceCheckPanel
+from adl.core.models import StationLink
+from adl.core.source_checks import (
+    CHECK_STATION_SOURCE,
+    ProbeStep,
+    SourceCheckResult,
+    SourceCheckStatus,
+)
+from adl.core.tests.factories import StationLinkFactory
+from adl.monitoring.models import SourceProbeResult
+from adl.monitoring.views.health import (
+    source_probe_cooldown_key,
+    station_source_check_cooldown_key,
+)
+
+ZERO_MATCH_STEP = ProbeStep(CHECK_STATION_SOURCE, 5, SourceCheckResult(
+    status=SourceCheckStatus.OK,
+    message="Resolved /data/2026/07/31; 0 file(s) matched.",
+    latency_ms=180,
+))
+
+
+class StationCheckViewTestCase(TestCase):
+    def setUp(self):
+        cache.clear()
+        self.addCleanup(cache.clear)
+        self.link = StationLinkFactory()
+        self.connection = self.link.network_connection
+        self.user = get_user_model().objects.create_superuser(
+            username="admin", email="admin@example.com", password="test-pass"
+        )
+        self.client.force_login(self.user)
+        self.url = reverse("station_link_check_source", args=[self.link.id])
+
+        # The base StationLink implements no contract; the view must see it
+        # as supported for the check paths under test
+        supported = patch.object(StationLink, "station_source_check_supported", True)
+        supported.start()
+        self.addCleanup(supported.stop)
+
+    def check(self, url=None, **kwargs):
+        return self.client.post(url or self.url, follow=True, **kwargs)
+
+
+class StationCheckPermissionTests(StationCheckViewTestCase):
+    def make_plain_user(self):
+        user = get_user_model().objects.create_user(
+            username="operator", email="op@example.com", password="test-pass"
+        )
+        user.user_permissions.add(Permission.objects.get(codename="access_admin"))
+        return user
+
+    def test_post_without_change_permission_never_fires_the_check(self):
+        self.client.force_login(self.make_plain_user())
+
+        with patch("adl.monitoring.views.health.run_station_source_check") as check:
+            response = self.client.post(self.url, follow=True)
+            xhr_response = self.client.post(
+                self.url, HTTP_X_REQUESTED_WITH="XMLHttpRequest"
+            )
+
+        check.assert_not_called()
+        self.assertContains(response, "do not have permission")
+        self.assertEqual(xhr_response.status_code, 403)
+
+
+class StationCheckRunTests(StationCheckViewTestCase):
+    def test_zero_matches_reports_ok_with_the_resolved_path(self):
+        with patch("adl.monitoring.views.health.run_station_source_check",
+                   return_value=ZERO_MATCH_STEP):
+            response = self.check()
+
+        self.assertEqual(response.status_code, 200)
+        # Zero matches is success: the resolved path and match count reach
+        # the operator, who judges better than a rule can
+        self.assertContains(response, "/data/2026/07/31")
+        self.assertContains(response, "0 file(s) matched")
+        row = SourceProbeResult.objects.get()
+        self.assertEqual(row.status, SourceCheckStatus.OK)
+
+    def test_the_result_persists_with_the_station_link_fk_set(self):
+        with patch("adl.monitoring.views.health.run_station_source_check",
+                   return_value=ZERO_MATCH_STEP):
+            self.check()
+
+        row = SourceProbeResult.objects.get()
+        self.assertEqual(row.station_link_id, self.link.id)
+        self.assertEqual(row.connection_id, self.connection.id)
+        self.assertEqual(row.check_id, CHECK_STATION_SOURCE)
+        self.assertEqual(row.layer, "source")
+
+    def test_a_failed_check_reports_the_failing_message(self):
+        failed = ProbeStep(CHECK_STATION_SOURCE, 5, SourceCheckResult(
+            status=SourceCheckStatus.FAILED, category="AUTH_FAILED",
+            message="530 Login incorrect"))
+
+        with patch("adl.monitoring.views.health.run_station_source_check",
+                   return_value=failed):
+            response = self.check()
+
+        self.assertContains(response, "530 Login incorrect")
+
+    def test_unsupported_station_link_gets_a_warning_and_no_row(self):
+        with patch.object(StationLink, "station_source_check_supported", False), \
+                patch("adl.monitoring.views.health.run_station_source_check") as check:
+            response = self.check()
+
+        check.assert_not_called()
+        self.assertContains(response, "does not implement")
+        self.assertFalse(SourceProbeResult.objects.exists())
+
+    def test_a_raising_check_does_not_release_the_cooldown(self):
+        with patch("adl.monitoring.views.health.run_station_source_check",
+                   side_effect=RuntimeError("boom")) as check:
+            first = self.check()
+            second = self.check()
+
+        self.assertEqual(check.call_count, 1)
+        self.assertEqual(first.status_code, 200)
+        self.assertContains(second, "has not recorded a result yet")
+
+
+class StationCheckCooldownTests(StationCheckViewTestCase):
+    def test_a_press_inside_the_cooldown_returns_the_stored_result_not_an_error(self):
+        with patch("adl.monitoring.views.health.run_station_source_check",
+                   return_value=ZERO_MATCH_STEP) as check:
+            self.check()
+            response = self.check()
+
+        self.assertEqual(check.call_count, 1)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "minute(s) ago")
+        self.assertContains(response, "0 file(s) matched")
+
+    def test_one_stations_press_does_not_answer_for_another(self):
+        # Two links on the same connection share a host; keying on the host
+        # alone would hand the second station the first one's verdict
+        other = StationLinkFactory(network_connection=self.connection)
+        other_url = reverse("station_link_check_source", args=[other.id])
+
+        with patch("adl.monitoring.views.health.run_station_source_check",
+                   return_value=ZERO_MATCH_STEP) as check:
+            self.check()
+            self.check(url=other_url)
+
+        self.assertEqual(check.call_count, 2)
+        self.assertEqual(
+            SourceProbeResult.objects.filter(station_link=other).count(), 1)
+
+    def test_checks_run_one_station_at_a_time_no_fan_out(self):
+        # One press, one check, one row — nothing iterates sibling links
+        StationLinkFactory(network_connection=self.connection)
+
+        with patch("adl.monitoring.views.health.run_station_source_check",
+                   return_value=ZERO_MATCH_STEP) as check:
+            self.check()
+
+        self.assertEqual(check.call_count, 1)
+        self.assertEqual(SourceProbeResult.objects.count(), 1)
+
+
+class StationCheckCooldownKeyTests(StationCheckViewTestCase):
+    def test_key_is_host_and_station_link(self):
+        self.connection.get_source_endpoint = lambda: ("ftp.example.org", 21)
+
+        key = station_source_check_cooldown_key(self.link)
+
+        self.assertIn("ftp.example.org", key)
+        self.assertIn(str(self.link.id), key)
+
+    def test_two_links_on_one_host_get_distinct_keys(self):
+        other = StationLinkFactory(network_connection=self.connection)
+        self.connection.get_source_endpoint = lambda: ("ftp.example.org", 21)
+        other.network_connection = self.connection
+
+        self.assertNotEqual(station_source_check_cooldown_key(self.link),
+                            station_source_check_cooldown_key(other))
+
+    def test_key_is_independent_of_the_connection_probe_key(self):
+        self.connection.get_source_endpoint = lambda: ("ftp.example.org", 21)
+        self.link.network_connection = self.connection
+
+        self.assertNotEqual(station_source_check_cooldown_key(self.link),
+                            source_probe_cooldown_key(self.connection))
+
+    def test_unimplemented_endpoint_falls_back_to_connection_and_link(self):
+        other = StationLinkFactory()
+
+        self.assertNotEqual(station_source_check_cooldown_key(self.link),
+                            station_source_check_cooldown_key(other))
+        self.assertIn(str(self.link.id),
+                      station_source_check_cooldown_key(self.link))
+
+
+class InspectPanelTests(StationCheckViewTestCase):
+    """The button and its result render on the station-link inspect page via
+    the panel component; hidden, not disabled, when unpermitted or
+    unsupported. Station-scope drift renders there as advisory."""
+
+    def render_panel(self, user=None):
+        request = RequestFactory().get("/")
+        request.user = user or self.user
+        return StationLinkSourceCheckPanel().render_html({
+            "station_link": self.link,
+            "request": request,
+        })
+
+    def test_button_renders_for_a_permitted_user_on_a_supported_link(self):
+        html = self.render_panel()
+
+        self.assertIn("Check station source now", html)
+        self.assertIn(self.url, html)
+
+    def test_button_is_hidden_when_unsupported(self):
+        with patch.object(StationLink, "station_source_check_supported", False):
+            html = self.render_panel()
+
+        self.assertNotIn("Check station source now", html)
+        self.assertNotIn(self.url, html)
+
+    def test_button_is_hidden_for_an_unpermitted_user(self):
+        plain = get_user_model().objects.create_user(
+            username="viewer", email="viewer@example.com", password="test-pass"
+        )
+
+        html = self.render_panel(user=plain)
+
+        self.assertNotIn("Check station source now", html)
+
+    def test_latest_station_scope_result_renders_with_its_message(self):
+        SourceProbeResult.objects.create(
+            connection=self.connection, station_link=self.link,
+            check_id=CHECK_STATION_SOURCE, layer="source",
+            status=SourceCheckStatus.OK,
+            message="Resolved /data/2026/07/31; 0 file(s) matched.",
+            latency_ms=180, at=dj_tz.now(),
+        )
+
+        html = self.render_panel()
+
+        self.assertIn("0 file(s) matched", html)
+
+    def test_a_connection_scope_result_is_not_shown_as_the_stations(self):
+        SourceProbeResult.objects.create(
+            connection=self.connection, station_link=None,
+            check_id="source_check", layer="source",
+            status=SourceCheckStatus.OK, message="listed 3 files",
+            at=dj_tz.now(),
+        )
+
+        html = self.render_panel()
+
+        self.assertNotIn("listed 3 files", html)
+
+    def test_station_scope_drift_renders_as_advisory(self):
+        from adl.monitoring.health import ConfigurationDrift
+
+        drifted = ConfigurationDrift(
+            drifted=True, evaluated=True, fields=("file_pattern",),
+            messages=("file pattern: this field is required",))
+        with patch("adl.core.components.configuration_drift",
+                   return_value=drifted):
+            html = self.render_panel()
+
+        self.assertIn("Configuration drift", html)
+        self.assertIn("file pattern: this field is required", html)

--- a/adl/src/adl/monitoring/urls.py
+++ b/adl/src/adl/monitoring/urls.py
@@ -9,7 +9,11 @@ from .views import (
 )
 
 from .views.activity import NetworkConnectionActivityView, DispatchChannelMonitoringView
-from .views.health import connection_health, connection_probe_source
+from .views.health import (
+    connection_health,
+    connection_probe_source,
+    station_link_check_source,
+)
 
 urlpatterns = [
     path('connection/<int:connection_id>/health/', connection_health,
@@ -34,5 +38,7 @@ urlpatterns = [
     path('dispatch-channel/<int:channel_id>/', dispatch_channel_monitoring,
          name='dispatch_channel_monitoring'),
     path('station-link/<int:link_id>/', station_link_monitoring,
-         name='station_link_monitoring')
+         name='station_link_monitoring'),
+    path('station-link/<int:link_id>/check-source/', station_link_check_source,
+         name='station_link_check_source')
 ]

--- a/adl/src/adl/monitoring/views/health.py
+++ b/adl/src/adl/monitoring/views/health.py
@@ -10,8 +10,12 @@ from django.urls import reverse
 from django.utils import timezone as dj_timezone
 from django.utils.translation import gettext as _
 
-from adl.core.models import NetworkConnection
-from adl.core.source_checks import SourceCheckStatus, run_source_probe
+from adl.core.models import NetworkConnection, StationLink
+from adl.core.source_checks import (
+    SourceCheckStatus,
+    run_source_probe,
+    run_station_source_check,
+)
 
 from ..constants import LAYER_LABELS, LAYER_SOURCE, PROBE_LAYER_IDS
 from ..health import EVALUATED_LAYERS, evaluate_connection_health, probe_age_minutes
@@ -31,6 +35,23 @@ PROBE_COOLDOWN_SECONDS = 60
 PROBE_PERMISSION = "core.change_networkconnection"
 
 
+def _source_host(connection):
+    """The connection's source host for cooldown keying, or ``None`` where
+    the endpoint is unimplemented or its lookup raises — a plugin's endpoint
+    lookup is never trusted to succeed, and a raising override must not turn
+    a POST into a server error."""
+    try:
+        endpoint = connection.get_source_endpoint()
+    except Exception:
+        logger.exception("[SOURCE PROBE] get_source_endpoint raised for connection %s",
+                         connection.id)
+        return None
+    if endpoint is None:
+        return None
+    host, _port = endpoint
+    return host
+
+
 def source_probe_cooldown_key(connection):
     """
     The cooldown cache key for one connection's source, keyed on the host
@@ -38,18 +59,23 @@ def source_probe_cooldown_key(connection):
     share one budget. Falls back to the connection id where the endpoint is
     unimplemented.
     """
-    try:
-        endpoint = connection.get_source_endpoint()
-    except Exception:
-        # A plugin's endpoint lookup is never trusted to succeed — a raising
-        # override must not turn the probe POST into a server error
-        logger.exception("[SOURCE PROBE] get_source_endpoint raised for connection %s",
-                         connection.id)
-        endpoint = None
-    if endpoint is not None:
-        host, _port = endpoint
+    host = _source_host(connection)
+    if host is not None:
         return f"adl_source_probe_cooldown:{host}"
     return f"adl_source_probe_cooldown:connection:{connection.id}"
+
+
+def station_source_check_cooldown_key(station_link):
+    """
+    The cooldown cache key for one station link's source check, keyed on
+    **(host, station link)** and independent of the connection probe —
+    host-only keying would hand one station another station's verdict.
+    """
+    host = _source_host(station_link.network_connection)
+    if host is not None:
+        return f"adl_station_source_check_cooldown:{host}:{station_link.id}"
+    return (f"adl_station_source_check_cooldown:"
+            f"connection:{station_link.network_connection_id}:{station_link.id}")
 
 
 def connection_health(request, connection_id):
@@ -204,6 +230,127 @@ def _report_existing_probe(request, connection, claim, now):
             _("A probe for this source was started less than a minute ago "
               "and has not recorded a result yet. Refresh shortly, or try "
               "again in a minute."),
+        )
+
+
+def _station_link_page(station_link):
+    """Redirect back to the station link's inspect page — the page the
+    check button lives on. Falls back to the monitoring timeline where the
+    inspect viewset is not registered for this model."""
+    from adl.core.utils import get_url_for_station_link
+    try:
+        return redirect(get_url_for_station_link(station_link, "inspect",
+                                                 takes_args=True))
+    except Exception:
+        return redirect("station_link_monitoring", link_id=station_link.id)
+
+
+def station_link_check_source(request, link_id):
+    """
+    Run the on-demand station-scope source check (layer 5) for **one**
+    station link — synchronously, one station at a time, with no fan-out
+    anywhere: 27 stations means 27 connect/auth/list cycles, and a burst of
+    failed authentications is what actually trips a ban.
+
+    Cooldown mechanics mirror the connection probe, but the key is
+    **(host, station link)** — one station's press must never answer for
+    another's. The result persists against the same probe-result model with
+    the station-link FK set; the connection evaluator filters those rows
+    out by query, so this check can never move the connection's verdict.
+    """
+    station_link = get_object_or_404(StationLink, id=link_id)
+
+    if not request.user.has_perm(PROBE_PERMISSION):
+        raise PermissionDenied
+
+    inspect_page = _station_link_page(station_link)
+    if request.method != "POST":
+        return inspect_page
+
+    if not station_link.station_source_check_supported:
+        messages.warning(
+            request,
+            _("This plugin does not implement the station source check, so "
+              "there is nothing to run."),
+        )
+        return inspect_page
+
+    now = dj_timezone.now()
+    key = station_source_check_cooldown_key(station_link)
+    if not cache.add(key, now.isoformat(), timeout=PROBE_COOLDOWN_SECONDS):
+        _report_existing_station_check(request, station_link, cache.get(key), now)
+        return inspect_page
+
+    try:
+        step = run_station_source_check(station_link)
+    except Exception:
+        # The claim stays: a crashed check still dialled the host, so the
+        # budget is spent either way
+        logger.exception("[SOURCE PROBE] Station check crashed for station link %s",
+                         station_link.id)
+        messages.error(
+            request,
+            _("The station source check could not run to completion. See "
+              "the application logs for the cause."),
+        )
+        return inspect_page
+
+    SourceProbeResult.objects.create(
+        connection=station_link.network_connection,
+        station_link=station_link,
+        check_id=step.check_id,
+        layer=PROBE_LAYER_IDS[step.layer],
+        status=step.result.status,
+        category=step.result.category,
+        message=step.result.message,
+        latency_ms=step.result.latency_ms,
+        at=now,
+    )
+
+    _report_station_check_outcome(request, step)
+    return inspect_page
+
+
+def _report_existing_station_check(request, station_link, claim, now):
+    """A press inside the cooldown: the shared result is the limit, so the
+    answer is this station's own stored result (with its age and origin) or
+    the in-flight state — never a refusal."""
+    claimed_at = _parse_claim(claim)
+    newest = (SourceProbeResult.objects
+              .filter(station_link=station_link)
+              .order_by("-at")
+              .first())
+
+    if newest is not None and (claimed_at is None or newest.at >= claimed_at):
+        messages.info(
+            request,
+            _("Checked %(minutes)d minute(s) ago (on-demand station check): "
+              "%(message)s — one check per station per minute; this shared "
+              "result is the limit.")
+            % {"minutes": probe_age_minutes(now, newest.at),
+               "message": newest.message},
+        )
+    else:
+        messages.info(
+            request,
+            _("A check for this station was started less than a minute ago "
+              "and has not recorded a result yet. Refresh shortly, or try "
+              "again in a minute."),
+        )
+
+
+def _report_station_check_outcome(request, step):
+    result = step.result
+    if result.status == SourceCheckStatus.FAILED:
+        messages.error(request, result.message)
+    elif result.status == SourceCheckStatus.OK:
+        # Zero matches is OK by design: the resolved path and match count
+        # in the message let the operator judge better than a rule can
+        messages.success(request, result.message)
+    else:
+        messages.warning(
+            request,
+            _("The check ran, but the plugin did not return a usable result."),
         )
 
 


### PR DESCRIPTION
Closes #184 (spec: #171, decision section 7).

## What this adds

- **`StationLink.check_station_source()`** — a distinct station-scope contract with a base default of `UNSUPPORTED`, independently answerable from the connection-scope `check_source()`. Runs through the same normaliser (`_plugin_check_step`, shared with the connection probe's source step) under the same 15s wall-clock bound.
- **`run_station_source_check()`** — one step, one station at a time, no fan-out anywhere; no DNS/TCP step (the connection probe owns the network path).
- **POST view `station_link_check_source`** — mirrors the connection probe's mechanics (permission `core.change_networkconnection`, 60s cooldown claimed with an atomic `cache.add` before firing, stored-result-not-error inside the cooldown, claim never released on a crash), but keyed on **(host, station link)** so one station's press never answers for another's.
- **Persistence** — results land in `SourceProbeResult` with the station-link FK set and their own `check_id` (`station_source_check`); the connection evaluator's `station_link__isnull=True` filter excludes them by query. A new evaluator test asserts a fresh FAILED station-scope source row cannot move the connection's verdict.
- **Inspect-page panel** — `StationLinkSourceCheckPanel` on the existing station-link inspect page: the check button (hidden, not disabled, when unpermitted or unsupported), the station's own latest result with age and latency, and the station-scope configuration-drift advisory.
- **Zero matches is `OK`** — the resolved path and match count travel in the message; the view surfaces the message itself on success.

## Tests

- `adl.core.tests.test_source_checks` — contract independence, zero-match OK, malformed/raising/wall-clock behaviour of the runner.
- `adl.monitoring.tests.test_station_source_check_view` — view-seam permission, keying (`(host, station link)`, independence from the connection probe key), cooldown/in-flight/crash TTL behaviour, no fan-out, panel rendering (button visibility, own-result-only, drift advisory).
- `adl.monitoring.tests.test_health` — station-scope source rows excluded from the connection verdict by query.

Full suite: 344 tests, green.