### PR TITLE
Bump version to 0.8.8

### DIFF
--- a/adl/src/adl/version.py
+++ b/adl/src/adl/version.py
@@ -1,6 +1,6 @@
 # major.minor.patch.release.number
 # release must be one of alpha, beta, rc, or final
-VERSION = (0, 8, 7, "final", 0)
+VERSION = (0, 8, 8, "final", 0)
 
 
 def get_semver_version(version):


### PR DESCRIPTION
Version 0.8.7 → 0.8.8. Rolls up the ingestion diagnostic work (spec #171: verdict store, health headline, diagnostic page, source probes, dependency pins) and the template comment convention (#206), plus the proving plugin-side contracts landed in adl-ftp-plugin#3 (#188).