### PR TITLE
fix: contain a dispatch channel's test_connection return in core

### DIFF
--- a/adl/src/adl/core/dispatch_checks.py
+++ b/adl/src/adl/core/dispatch_checks.py
@@ -1,0 +1,118 @@
+"""
+Core-side containment for :meth:`DispatchChannel.test_connection`.
+
+``test_connection()`` is documented on the base class as returning a dict and
+never raising, but every implementation past ``Wis2BoxUpload`` lives in an
+independently-versioned plugin repo that upgrades on its own schedule. The
+contract had already drifted on its first out-of-core implementation —
+``adl-s3-plugin`` returned a ``(bool, str)`` tuple, and the admin's "Test
+connection" button raised ``TypeError`` on ``result["supported"]`` rather than
+reporting anything at all.
+
+So core does not trust the return. :func:`run_dispatch_connection_test` calls
+the channel and passes whatever comes back through
+:func:`normalise_dispatch_test_result`, which reports a non-conforming return
+as a channel-side failure naming the offending type. The next plugin to drift
+degrades to a legible message instead of a 500.
+
+Mirrors :mod:`adl.core.source_checks` on the ingestion side (decision #152),
+without converging on its ``SourceCheckResult`` shape — that retrofit reaches
+into sibling plugin repos and was deliberately left out of scope there.
+"""
+
+import logging
+import time
+from collections.abc import Mapping
+
+from django.utils.translation import gettext as _
+
+logger = logging.getLogger(__name__)
+
+# Keys a conforming `test_connection()` must supply. `latency_ms` is not
+# among them: the caller times the call anyway, so an omitted latency is
+# filled in rather than treated as a broken result.
+REQUIRED_RESULT_KEYS = ("ok", "supported", "message")
+
+
+def _malformed(message):
+    """A malformed return is the channel's failure, not an unsupported
+    channel type: ``supported`` stays True so the admin renders it as an
+    error rather than the softer "not supported for this channel type"."""
+    return {"ok": False, "supported": True, "message": message, "latency_ms": None}
+
+
+def normalise_dispatch_test_result(value, channel_type=None, measured_ms=None):
+    """
+    Return a well-formed test-connection dict for any channel return.
+
+    A non-mapping return, or one missing a required key, is reported as a
+    malformed result naming ``channel_type``. Otherwise the verdict is taken
+    as given and only coerced: ``ok`` and ``supported`` to bool, ``message``
+    to str, and an unreadable ``latency_ms`` to ``measured_ms`` — a bad
+    latency should never cost the operator the verdict it accompanies.
+
+    ``measured_ms`` is the caller's own timing of the probe, used whenever
+    the channel does not report a usable one. The admin's success message
+    renders the latency unconditionally, so leaving it None would put
+    "(None ms)" in front of an operator.
+    """
+    context = {"channel": channel_type or _("The channel")}
+
+    if not isinstance(value, Mapping):
+        return _malformed(
+            _("%(channel)s returned %(type)s instead of a test-connection dict.")
+            % {**context, "type": type(value).__name__}
+        )
+
+    missing = [key for key in REQUIRED_RESULT_KEYS if key not in value]
+    if missing:
+        return _malformed(
+            _("%(channel)s returned a test-connection dict missing %(keys)s.")
+            % {**context, "keys": ", ".join(missing)}
+        )
+
+    return {
+        "ok": bool(value["ok"]),
+        "supported": bool(value["supported"]),
+        "message": str(value["message"]),
+        "latency_ms": _coerce_latency(value.get("latency_ms"), measured_ms),
+    }
+
+
+def _coerce_latency(value, fallback):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return fallback
+
+
+def run_dispatch_connection_test(channel):
+    """
+    Probe ``channel``'s destination and return a well-formed result dict.
+
+    Both failure modes the base-class docstring only asks implementations to
+    avoid are contained here: a raised exception becomes a reported failure,
+    and a non-conforming return becomes a malformed-result message. The
+    probe's own time bound is still the implementation's to keep.
+    """
+    channel_type = type(channel).__name__
+    started = time.monotonic()
+
+    def elapsed_ms():
+        return int((time.monotonic() - started) * 1000)
+
+    try:
+        raw = channel.test_connection()
+    except Exception as e:
+        logger.exception("[DISPATCH TEST] %s raised for channel %s", channel_type, channel.id)
+        return {
+            "ok": False,
+            "supported": True,
+            "message": _("The connection test raised %(type)s: %(error)s")
+                       % {"type": type(e).__name__, "error": e},
+            "latency_ms": elapsed_ms(),
+        }
+
+    return normalise_dispatch_test_result(
+        raw, channel_type=channel_type, measured_ms=elapsed_ms()
+    )

--- a/adl/src/adl/core/models.py
+++ b/adl/src/adl/core/models.py
@@ -1138,6 +1138,11 @@ class DispatchChannel(PolymorphicModel, ClusterableModel):
         destination (reachability + authentication). Implementations must
         never raise and must never block for more than ~10 seconds.
 
+        The return is normalised by core and never trusted as-is — call
+        :func:`adl.core.dispatch_checks.run_dispatch_connection_test` rather
+        than this method directly, so a channel that raises or returns the
+        wrong shape reports a failure instead of crashing the caller.
+
         :return: dict with keys ``ok`` (bool), ``supported`` (bool),
             ``message`` (str) and ``latency_ms`` (int or None).
         """

--- a/adl/src/adl/core/tests/test_dispatch_test_connection.py
+++ b/adl/src/adl/core/tests/test_dispatch_test_connection.py
@@ -4,6 +4,10 @@ from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.urls import reverse
 
+from adl.core.dispatch_checks import (
+    normalise_dispatch_test_result,
+    run_dispatch_connection_test,
+)
 from adl.core.models import DispatchChannel, Wis2BoxUpload
 from .factories import Wis2BoxUploadFactory
 
@@ -17,6 +21,99 @@ class BaseTestConnectionContractTests(TestCase):
         self.assertFalse(result["supported"])
         self.assertFalse(result["ok"])
         self.assertIn("not supported", result["message"])
+
+
+class NormaliseDispatchTestResultTests(TestCase):
+    """A channel type lives in its own repo and upgrades on its own schedule,
+    so core never trusts what `test_connection()` hands back."""
+
+    def test_conforming_result_passes_through_unchanged(self):
+        result = normalise_dispatch_test_result(
+            {"ok": True, "supported": True, "message": "reachable", "latency_ms": 12}
+        )
+
+        self.assertEqual(
+            result,
+            {"ok": True, "supported": True, "message": "reachable", "latency_ms": 12},
+        )
+
+    def test_missing_latency_falls_back_to_the_callers_measurement(self):
+        """The admin renders the latency unconditionally on success, so an
+        omitted one must not reach the operator as "(None ms)"."""
+        result = normalise_dispatch_test_result(
+            {"ok": False, "supported": True, "message": "bucket missing"}, measured_ms=7
+        )
+
+        self.assertEqual(result["latency_ms"], 7)
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["message"], "bucket missing")
+
+    def test_unreadable_latency_falls_back_without_losing_the_verdict(self):
+        result = normalise_dispatch_test_result(
+            {"ok": True, "supported": True, "message": "reachable", "latency_ms": "fast"},
+            measured_ms=7,
+        )
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["latency_ms"], 7)
+
+    def test_tuple_return_is_reported_as_malformed_not_indexed(self):
+        """The shape `adl-s3-plugin` shipped: `result["supported"]` on a tuple
+        raised TypeError and 500'd the admin button."""
+        result = normalise_dispatch_test_result((True, "Connection successful"), channel_type="S3Upload")
+
+        self.assertTrue(result["supported"])
+        self.assertFalse(result["ok"])
+        self.assertIn("S3Upload", result["message"])
+        self.assertIn("tuple", result["message"])
+
+    def test_result_missing_required_keys_is_reported_as_malformed(self):
+        result = normalise_dispatch_test_result({"ok": True}, channel_type="S3Upload")
+
+        self.assertTrue(result["supported"])
+        self.assertFalse(result["ok"])
+        self.assertIn("supported", result["message"])
+        self.assertIn("message", result["message"])
+
+    def test_none_return_is_reported_as_malformed(self):
+        result = normalise_dispatch_test_result(None, channel_type="S3Upload")
+
+        self.assertFalse(result["ok"])
+        self.assertIn("NoneType", result["message"])
+
+
+class RunDispatchConnectionTestTests(TestCase):
+    def setUp(self):
+        self.channel = Wis2BoxUploadFactory()
+
+    def test_probe_return_is_normalised(self):
+        with patch.object(Wis2BoxUpload, "test_connection", return_value=(True, "ok")):
+            result = run_dispatch_connection_test(self.channel)
+
+        self.assertFalse(result["ok"])
+        self.assertTrue(result["supported"])
+        self.assertIn("Wis2BoxUpload", result["message"])
+
+    def test_a_channel_omitting_latency_still_reports_a_number(self):
+        with patch.object(
+            Wis2BoxUpload, "test_connection",
+            return_value={"ok": True, "supported": True, "message": "reachable"},
+        ):
+            result = run_dispatch_connection_test(self.channel)
+
+        self.assertTrue(result["ok"])
+        self.assertIsInstance(result["latency_ms"], int)
+
+    def test_raising_probe_is_reported_as_a_failure_not_propagated(self):
+        with patch.object(
+            Wis2BoxUpload, "test_connection", side_effect=RuntimeError("client blew up")
+        ):
+            result = run_dispatch_connection_test(self.channel)
+
+        self.assertFalse(result["ok"])
+        self.assertTrue(result["supported"])
+        self.assertIn("RuntimeError", result["message"])
+        self.assertIn("client blew up", result["message"])
 
 
 class Wis2BoxTestConnectionTests(TestCase):
@@ -71,6 +168,15 @@ class TestConnectionAdminViewTests(TestCase):
         mock_probe.assert_called_once_with()
         rendered_messages = [str(m) for m in response.context["messages"]]
         self.assertTrue(any("reachable" in m for m in rendered_messages))
+
+    def test_malformed_probe_return_renders_an_error_instead_of_500ing(self):
+        with patch.object(Wis2BoxUpload, "test_connection", return_value=(True, "Connection successful")):
+            response = self.client.post(
+                self.url, HTTP_REFERER="/admin/dispatch-channels/", follow=True
+            )
+
+        rendered_messages = [str(m) for m in response.context["messages"]]
+        self.assertTrue(any("Wis2BoxUpload" in m for m in rendered_messages))
 
     def test_anonymous_cannot_probe(self):
         self.client.logout()

--- a/adl/src/adl/core/views.py
+++ b/adl/src/adl/core/views.py
@@ -30,6 +30,7 @@ from .constants import (
     OSCAR_SURFACE_REQUIRED_CSV_COLUMNS,
     PREDEFINED_DATA_PARAMETERS
 )
+from .dispatch_checks import run_dispatch_connection_test
 from .forms import (
     StationLoaderForm,
     OSCARStationImportForm,
@@ -1345,11 +1346,14 @@ def test_dispatch_channel_connection(request, channel_id):
 
     Runs in the web process on purpose: a wedged dispatch queue must not be
     able to mask a destination health check.
+
+    The probe is an out-of-core plugin's code, so its return goes through
+    ``run_dispatch_connection_test`` rather than being read directly.
     """
     if request.method == 'POST':
         dispatch_channel = get_object_or_404(DispatchChannel, id=channel_id)
 
-        result = dispatch_channel.test_connection()
+        result = run_dispatch_connection_test(dispatch_channel)
 
         if not result["supported"]:
             messages.warning(request, result["message"])


### PR DESCRIPTION
Fixes #157.

`DispatchChannel.test_connection()` documents a dict return and asks implementations never to raise, but every implementation past `Wis2BoxUpload` lives in an independently-versioned plugin repo. The contract had already drifted on its first out-of-core implementation: `adl-s3-plugin` returned a `(bool, str)` tuple, so `result["supported"]` in `views.py` raised `TypeError` and the admin's "Test connection" button 500'd regardless of whether the bucket was actually reachable.

## What changed

New `adl/src/adl/core/dispatch_checks.py`:

- `run_dispatch_connection_test(channel)` — the call site core uses instead of invoking the probe directly. A raised exception becomes a reported failure; the return goes through the normaliser.
- `normalise_dispatch_test_result(...)` — reports a non-mapping return, or one missing `ok`/`supported`/`message`, as a channel-side failure naming the offending type. `supported` stays `True` for a malformed return so the admin renders it as an error rather than the softer "not supported for this channel type".

`views.py:1356` now calls the wrapper. The base-class docstring in `models.py` points implementers and callers at it.

Mirrors the ingestion side's `source_checks` normaliser (#152) without converging on its `SourceCheckResult` shape — that retrofit reaches into sibling plugin repos and #152 put it out of scope.

## One thing this surfaced

The admin's success branch renders the latency unconditionally, so a conforming channel that merely omitted `latency_ms` would have shown operators "Connection successful (None ms)". An omitted or unreadable latency now falls back to core's own timing of the call.

## Paired change

The plugin-side half is wmo-raf/adl-s3-plugin#1, which makes `BaseS3Upload.test_connection` return the documented dict. The two are independent — this PR makes the button degrade to a legible message on its own, and stays correct once the plugin conforms.

## Not covered here

- **No test proves `S3Upload.test_connection` now returns the right shape** — which is the root cause #157 named. The tests here simulate drift by patching `Wis2BoxUpload` to return a tuple; they prove the normaliser copes, not that the plugin conforms. `adl-s3-plugin` has no test suite at all and standing one up is outside this issue.
- **No wall-clock bound on the probe.** It runs third-party plugin code synchronously in the web process, and "must never block for more than ~10 seconds" remains an honour-system docstring. Filed as #211.

## Testing

16 tests in `test_dispatch_test_connection.py` (8 new), including one that reproduces the exact tuple return that 500'd the button. Full suite: 430 passing.
