### PR TITLE
fix: bound and rate-limit a dispatch channel's connection test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ adl/src/adl/
 │   ├── registries.py  # Plugin base class and PluginRegistry
 │   ├── registry.py    # Generic Registry/Instance base classes
 │   ├── tasks.py       # Celery tasks for ingestion and dispatch
+│   ├── probes.py      # Shared wall clock + press cooldown for on-demand probes
 │   ├── dispatchers/   # Data dispatch implementations (wis2box, etc.)
 │   ├── qc/            # Quality control pipeline and validators
 │   └── logging.py     # TaskLogger for audit trails

--- a/adl/src/adl/core/dispatch_checks.py
+++ b/adl/src/adl/core/dispatch_checks.py
@@ -9,11 +9,13 @@ contract had already drifted on its first out-of-core implementation —
 connection" button raised ``TypeError`` on ``result["supported"]`` rather than
 reporting anything at all.
 
-So core does not trust the return. :func:`run_dispatch_connection_test` calls
-the channel and passes whatever comes back through
-:func:`normalise_dispatch_test_result`, which reports a non-conforming return
-as a channel-side failure naming the offending type. The next plugin to drift
-degrades to a legible message instead of a 500.
+So core does not trust the return, and does not trust the clock either.
+:func:`run_dispatch_connection_test` calls the channel under the shared
+wall-clock bound in :mod:`adl.core.probes` and passes whatever comes back
+through :func:`normalise_dispatch_test_result`, which reports a non-conforming
+return as a channel-side failure naming the offending type. The next plugin to
+drift — in shape or in latency — degrades to a legible message instead of a
+500 or a wedged web worker.
 
 Mirrors :mod:`adl.core.source_checks` on the ingestion side (decision #152),
 without converging on its ``SourceCheckResult`` shape — that retrofit reaches
@@ -26,12 +28,28 @@ from collections.abc import Mapping
 
 from django.utils.translation import gettext as _
 
+from .probes import PROBE_WALL_CLOCK_SECONDS, ProbeTimeout, run_bounded
+
 logger = logging.getLogger(__name__)
 
 # Keys a conforming `test_connection()` must supply. `latency_ms` is not
 # among them: the caller times the call anyway, so an omitted latency is
 # filled in rather than treated as a broken result.
 REQUIRED_RESULT_KEYS = ("ok", "supported", "message")
+
+
+def channel_implements_test_connection(channel) -> bool:
+    """True when the channel type overrides ``test_connection()``.
+
+    Answerable without performing any I/O, which is what lets a caller tell
+    "this press will dial a destination" from "this press cannot dial
+    anything" — the base implementation returns its not-supported dict
+    without going near the network, so such a press must not spend a
+    cooldown budget. Mirrors
+    :func:`adl.core.source_checks.connection_implements_check_source`.
+    """
+    from adl.core.models import DispatchChannel
+    return type(channel).test_connection is not DispatchChannel.test_connection
 
 
 def _malformed(message):
@@ -86,14 +104,20 @@ def _coerce_latency(value, fallback):
         return fallback
 
 
-def run_dispatch_connection_test(channel):
+def run_dispatch_connection_test(channel, timeout_seconds=PROBE_WALL_CLOCK_SECONDS):
     """
     Probe ``channel``'s destination and return a well-formed result dict.
 
-    Both failure modes the base-class docstring only asks implementations to
+    All three failure modes the base-class docstring asks implementations to
     avoid are contained here: a raised exception becomes a reported failure,
-    and a non-conforming return becomes a malformed-result message. The
-    probe's own time bound is still the implementation's to keep.
+    a non-conforming return becomes a malformed-result message, and a probe
+    that outruns ``timeout_seconds`` becomes a failure naming the budget.
+
+    The bound covers the whole call, not the destination-facing request
+    inside it — a channel that builds its client eagerly (``adl-s3-plugin``
+    dials ``head_bucket`` from ``__init__``) blocks before its own
+    ``test_connection`` body reaches any timeout it might set. The abandoned
+    worker is left to finish on its own and cannot extend this call.
     """
     channel_type = type(channel).__name__
     started = time.monotonic()
@@ -102,7 +126,20 @@ def run_dispatch_connection_test(channel):
         return int((time.monotonic() - started) * 1000)
 
     try:
-        raw = channel.test_connection()
+        raw = run_bounded(channel.test_connection, timeout_seconds)
+    except ProbeTimeout:
+        logger.warning(
+            "[DISPATCH TEST] %s exceeded the %ss budget for channel %s",
+            channel_type, timeout_seconds, channel.id,
+        )
+        return {
+            "ok": False,
+            "supported": True,
+            "message": _("%(channel)s did not complete its connection test "
+                         "within the %(seconds)s-second budget.")
+                       % {"channel": channel_type, "seconds": timeout_seconds},
+            "latency_ms": elapsed_ms(),
+        }
     except Exception as e:
         logger.exception("[DISPATCH TEST] %s raised for channel %s", channel_type, channel.id)
         return {

--- a/adl/src/adl/core/models.py
+++ b/adl/src/adl/core/models.py
@@ -1138,10 +1138,16 @@ class DispatchChannel(PolymorphicModel, ClusterableModel):
         destination (reachability + authentication). Implementations must
         never raise and must never block for more than ~10 seconds.
 
-        The return is normalised by core and never trusted as-is — call
+        Neither obligation is trusted. Call
         :func:`adl.core.dispatch_checks.run_dispatch_connection_test` rather
-        than this method directly, so a channel that raises or returns the
-        wrong shape reports a failure instead of crashing the caller.
+        than this method directly: it reports a raised exception or a
+        wrong-shaped return as a failure instead of crashing the caller, and
+        it enforces a hard wall clock of
+        :data:`adl.core.probes.PROBE_WALL_CLOCK_SECONDS` so a channel that
+        blocks — anywhere, including in the client it builds — cannot wedge
+        the web worker that pressed the button. The ~10 seconds above stays
+        the contract; the wall clock is only what happens when the contract
+        is broken, and the headroom between them is deliberate.
 
         :return: dict with keys ``ok`` (bool), ``supported`` (bool),
             ``message`` (str) and ``latency_ms`` (int or None).

--- a/adl/src/adl/core/probes.py
+++ b/adl/src/adl/core/probes.py
@@ -1,0 +1,153 @@
+"""
+The wall-clock bound and the press budget shared by every on-demand probe.
+
+Both directions of the system dial partner hosts from the web process on an
+operator's button press — the ingestion diagnostic's source probe
+(:mod:`adl.core.source_checks`) and the dispatch channel's connection test
+(:mod:`adl.core.dispatch_checks`) — and both call code that lives in an
+independently-versioned plugin repo. The base-class docstrings ask those
+implementations for a short, bounded check; nothing on the far side of a
+plugin boundary makes that true. A plugin that forgets ``timeout=`` does not
+return a bad verdict, it wedges a web worker.
+
+So the bound is core's, not the implementation's, and it lives here rather
+than on either side: nothing about a wall clock is ingestion-specific, and
+a private cross-import between the two check modules would make one of them
+the de facto home of a shared primitive.
+
+The discipline that must not regress is one line of *absence*.
+:func:`bounded_executor` deliberately shuts its executor down with
+``wait=False`` and is **not** implemented as ``with ThreadPoolExecutor(...)``:
+``with``-exit joins abandoned worker threads, which would let a stuck plugin
+call outlive the bound this module promises. The timed-out worker is
+abandoned to finish on its own.
+
+SIGALRM was considered and rejected: it only fires on the main thread of a
+POSIX process, and this repo runs under Daphne.
+
+The press budget lives here for the same reason. The wall clock bounds one
+press; nothing bounds ten of them, so :func:`claim_probe_cooldown` and
+:func:`read_probe_claim` give both buttons one claim-before-you-dial
+discipline. What a press inside the cooldown is *told* stays with each side,
+which has its own history to report from.
+"""
+
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FutureTimeoutError
+from contextlib import contextmanager
+from datetime import datetime
+
+from django.core.cache import cache
+
+# One probe may take at most this long, wall clock. Both sides already have
+# the same two-level shape — a ~10 s contract asked of implementations, and
+# a core wall above it — and the same number is used for both, so the worst
+# case an operator can experience is identical whichever button they press.
+PROBE_WALL_CLOCK_SECONDS = 15
+
+# One probe per target per minute. The wall clock bounds a single press;
+# nothing bounds ten of them, and a dead host would otherwise spawn a thread
+# per click. A cooldown claimed before the probe fires closes that without
+# the cross-target starvation a shared fixed thread pool would introduce.
+PROBE_COOLDOWN_SECONDS = 60
+
+
+class ProbeTimeout(Exception):
+    """The bound expired before the probed call returned.
+
+    Its own type rather than the executor's ``TimeoutError``: since Python
+    3.11 ``concurrent.futures.TimeoutError`` **is** the builtin
+    ``TimeoutError``, so catching that would silently also catch a probe
+    that failed fast with a socket timeout of its own and report it as
+    "did not complete within the budget" — a false statement about a call
+    that did complete.
+    """
+
+
+def _capture(fn):
+    """Run ``fn`` and box its outcome, so the worker never completes
+    exceptionally.
+
+    This is what keeps :class:`ProbeTimeout` unambiguous. ``Future.result()``
+    re-raises whatever the call raised, and since Python 3.11 the executor's
+    own ``TimeoutError`` is the builtin one — so a callee that failed fast
+    with its own socket timeout would be indistinguishable from an expired
+    wait. Boxed, the only exception ``result()`` can raise is the expiry.
+    """
+    try:
+        return True, fn()
+    except BaseException as e:  # noqa: BLE001 — re-raised verbatim below
+        return False, e
+
+
+def _submit_bounded(executor, fn, timeout_seconds):
+    """Submit ``fn`` to ``executor`` and wait no longer than the budget.
+
+    Raises :class:`ProbeTimeout` if the budget expires first, and whatever
+    ``fn`` raised otherwise. The floor keeps an already-spent budget from
+    being read as "wait forever". The abandoned worker is left to finish on
+    its own.
+    """
+    future = executor.submit(_capture, fn)
+    try:
+        succeeded, outcome = future.result(timeout=max(timeout_seconds, 0.001))
+    except FutureTimeoutError as e:
+        raise ProbeTimeout() from e
+
+    if succeeded:
+        return outcome
+    raise outcome
+
+
+@contextmanager
+def bounded_executor(max_workers):
+    """
+    Yield a ``bounded_call(fn, timeout_seconds)`` callable backed by a
+    private thread pool, for probes that chain several steps against one
+    shared deadline. Each call raises :class:`ProbeTimeout` on expiry.
+
+    The pool is shut down with ``wait=False``: a timed-out worker is
+    abandoned, never joined, so no step can outlive the budget it was given.
+    A bare ``ThreadPoolExecutor`` is not yielded, so no caller can
+    accidentally join it.
+    """
+    executor = ThreadPoolExecutor(max_workers=max_workers)
+    try:
+        yield lambda fn, timeout_seconds: _submit_bounded(executor, fn, timeout_seconds)
+    finally:
+        executor.shutdown(wait=False)
+
+
+def run_bounded(fn, timeout_seconds):
+    """Run ``fn`` under a hard wall clock of ``timeout_seconds``.
+
+    Raises :class:`ProbeTimeout` on expiry, leaving the abandoned worker to
+    finish on its own. For a single call; use :func:`bounded_executor` where
+    several steps share one deadline.
+    """
+    with bounded_executor(1) as bounded_call:
+        return bounded_call(fn, timeout_seconds)
+
+
+def claim_probe_cooldown(key, now):
+    """
+    Claim ``key``'s cooldown for this press, returning True when the claim
+    is ours and the probe may fire.
+
+    Atomic, and taken **before** the probe: the TTL is never extended on
+    completion and never released early, including when the probe raises,
+    since a crashed probe still dialled the host. That is what makes a
+    press inside the cooldown answerable with a message rather than a
+    second thread against a dead host.
+    """
+    return cache.add(key, now.isoformat(), timeout=PROBE_COOLDOWN_SECONDS)
+
+
+def read_probe_claim(key):
+    """The time the live claim on ``key`` was taken, or ``None`` when there
+    is none or it is unreadable — a claim is a cache value with a TTL, so a
+    caller must never depend on getting one back."""
+    try:
+        return datetime.fromisoformat(cache.get(key))
+    except (TypeError, ValueError):
+        return None

--- a/adl/src/adl/core/source_checks.py
+++ b/adl/src/adl/core/source_checks.py
@@ -21,20 +21,24 @@ smuggle an invented category into stored history.
 import logging
 import socket
 import time
-from concurrent.futures import ThreadPoolExecutor
-from concurrent.futures import TimeoutError as FutureTimeoutError
 from dataclasses import dataclass, replace
 from typing import Optional, Tuple
 
 from django.utils.translation import gettext as _
 
 from .classification import FAILURE_CATEGORIES
+# The wall clock and the executor discipline behind it are shared with the
+# dispatch side, so one press cannot cost an operator more than the other.
+# This probe spends that one budget across DNS, TCP and the plugin's own
+# source check together.
+from .probes import (
+    PROBE_WALL_CLOCK_SECONDS,
+    ProbeTimeout,
+    bounded_executor,
+    run_bounded,
+)
 
 logger = logging.getLogger(__name__)
-
-# One probe may take at most this long, wall clock, across DNS, TCP and the
-# plugin's own source check together
-PROBE_WALL_CLOCK_SECONDS = 15
 
 # Stable identifiers for the probe steps — these become stored
 # `SourceProbeResult.check_id` values, so they must never be renamed
@@ -133,12 +137,6 @@ def _elapsed_ms(started: float) -> int:
     return int((time.monotonic() - started) * 1000)
 
 
-def _bounded_call(executor, fn, timeout_seconds):
-    """Run ``fn`` with a wall-clock bound. Raises FutureTimeoutError on
-    expiry; the abandoned worker thread is left to finish on its own."""
-    return executor.submit(fn).result(timeout=max(timeout_seconds, 0.001))
-
-
 def run_source_probe(connection, timeout_seconds=PROBE_WALL_CLOCK_SECONDS) -> Tuple[ProbeStep, ...]:
     """
     Probe ``connection``'s source on demand: DNS resolution, then a TCP
@@ -152,43 +150,39 @@ def run_source_probe(connection, timeout_seconds=PROBE_WALL_CLOCK_SECONDS) -> Tu
     """
     deadline = time.monotonic() + timeout_seconds
 
-    # Not a context manager: `with` would join abandoned worker threads on
-    # exit, letting a stuck DNS lookup or plugin call outlive the wall-clock
-    # bound this function promises. Two workers, so a stuck DNS thread
-    # cannot queue-starve the later source check.
-    executor = ThreadPoolExecutor(max_workers=2)
-    try:
-        return _probe(connection, executor, deadline, timeout_seconds)
-    finally:
-        executor.shutdown(wait=False)
+    # Two workers, so a stuck DNS thread cannot queue-starve the later
+    # source check. The pool's abandon-don't-join discipline lives in
+    # `probes.bounded_executor`, in one place for both sides of the system.
+    with bounded_executor(2) as bounded_call:
+        return _probe(connection, bounded_call, deadline, timeout_seconds)
 
 
-def _probe(connection, executor, deadline, timeout_seconds) -> Tuple[ProbeStep, ...]:
+def _probe(connection, bounded_call, deadline, timeout_seconds) -> Tuple[ProbeStep, ...]:
     steps = []
 
     endpoint = connection.get_source_endpoint()
     if endpoint is not None:
         host, port = endpoint
 
-        dns_step = _dns_step(executor, host, port, deadline)
+        dns_step = _dns_step(bounded_call, host, port, deadline)
         steps.append(dns_step)
         if dns_step.result.status != SourceCheckStatus.OK:
             return tuple(steps)
 
-        tcp_step = _tcp_step(executor, host, port, deadline)
+        tcp_step = _tcp_step(bounded_call, host, port, deadline)
         steps.append(tcp_step)
         if tcp_step.result.status != SourceCheckStatus.OK:
             return tuple(steps)
 
-    steps.append(_source_step(connection, executor, deadline, timeout_seconds))
+    steps.append(_source_step(connection, bounded_call, deadline, timeout_seconds))
     return tuple(steps)
 
 
-def _dns_step(executor, host, port, deadline) -> ProbeStep:
+def _dns_step(bounded_call, host, port, deadline) -> ProbeStep:
     started = time.monotonic()
     try:
-        _bounded_call(executor, lambda: socket.getaddrinfo(host, port),
-                      deadline - time.monotonic())
+        bounded_call(lambda: socket.getaddrinfo(host, port),
+                     deadline - time.monotonic())
     except socket.gaierror as e:
         result = SourceCheckResult(
             status=SourceCheckStatus.FAILED,
@@ -197,7 +191,7 @@ def _dns_step(executor, host, port, deadline) -> ProbeStep:
                     % {"host": host, "error": e},
             latency_ms=_elapsed_ms(started),
         )
-    except FutureTimeoutError:
+    except ProbeTimeout:
         result = SourceCheckResult(
             status=SourceCheckStatus.FAILED,
             category="DNS_FAILURE",
@@ -214,7 +208,7 @@ def _dns_step(executor, host, port, deadline) -> ProbeStep:
     return ProbeStep(CHECK_DNS, 4, result)
 
 
-def _tcp_step(executor, host, port, deadline) -> ProbeStep:
+def _tcp_step(bounded_call, host, port, deadline) -> ProbeStep:
     started = time.monotonic()
     context = {"host": host, "port": port}
 
@@ -229,7 +223,7 @@ def _tcp_step(executor, host, port, deadline) -> ProbeStep:
         conn.close()
 
     try:
-        _bounded_call(executor, connect, deadline - time.monotonic())
+        bounded_call(connect, deadline - time.monotonic())
     except ConnectionRefusedError:
         result = SourceCheckResult(
             status=SourceCheckStatus.FAILED,
@@ -237,7 +231,7 @@ def _tcp_step(executor, host, port, deadline) -> ProbeStep:
             message=_("%(host)s refused a TCP connection on port %(port)s.") % context,
             latency_ms=_elapsed_ms(started),
         )
-    except (socket.timeout, TimeoutError, FutureTimeoutError):
+    except (socket.timeout, TimeoutError, ProbeTimeout):
         result = SourceCheckResult(
             status=SourceCheckStatus.FAILED,
             category="TCP_TIMEOUT",
@@ -261,22 +255,22 @@ def _tcp_step(executor, host, port, deadline) -> ProbeStep:
     return ProbeStep(CHECK_TCP, 4, result)
 
 
-def _source_step(connection, executor, deadline, timeout_seconds) -> ProbeStep:
+def _source_step(connection, bounded_call, deadline, timeout_seconds) -> ProbeStep:
     return _plugin_check_step(
-        CHECK_SOURCE, connection.check_source, executor, deadline, timeout_seconds,
+        CHECK_SOURCE, connection.check_source, bounded_call, deadline, timeout_seconds,
         log_context="connection %s" % connection.id,
     )
 
 
-def _plugin_check_step(check_id, check, executor, deadline, timeout_seconds,
+def _plugin_check_step(check_id, check, bounded_call, deadline, timeout_seconds,
                        log_context) -> ProbeStep:
     """Run one plugin-implemented layer-5 check under the wall-clock bound
     and pass its return through the normaliser — shared by the connection
     probe's source step and the station-scope check."""
     started = time.monotonic()
     try:
-        raw = _bounded_call(executor, check, deadline - time.monotonic())
-    except FutureTimeoutError:
+        raw = bounded_call(check, deadline - time.monotonic())
+    except ProbeTimeout:
         return ProbeStep(check_id, 5, SourceCheckResult(
             status=SourceCheckStatus.FAILED,
             message=_("The source check did not complete within the probe's "
@@ -311,15 +305,10 @@ def run_station_source_check(station_link,
     """
     deadline = time.monotonic() + timeout_seconds
 
-    # Not a context manager, for the same reason as run_source_probe: `with`
-    # would join an abandoned worker on exit, letting a stuck plugin call
-    # outlive the wall-clock bound this function promises
-    executor = ThreadPoolExecutor(max_workers=1)
-    try:
-        return _plugin_check_step(
-            CHECK_STATION_SOURCE, station_link.check_station_source,
-            executor, deadline, timeout_seconds,
-            log_context="station link %s" % station_link.id,
-        )
-    finally:
-        executor.shutdown(wait=False)
+    # One step, so the single-call bound is enough — no pool of its own to
+    # keep, and none of the discipline that pool would have to remember
+    return _plugin_check_step(
+        CHECK_STATION_SOURCE, station_link.check_station_source,
+        run_bounded, deadline, timeout_seconds,
+        log_context="station link %s" % station_link.id,
+    )

--- a/adl/src/adl/core/tests/test_dispatch_test_connection.py
+++ b/adl/src/adl/core/tests/test_dispatch_test_connection.py
@@ -1,6 +1,9 @@
+import threading
+import time
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
+from django.core.cache import cache
 from django.test import TestCase
 from django.urls import reverse
 
@@ -9,6 +12,8 @@ from adl.core.dispatch_checks import (
     run_dispatch_connection_test,
 )
 from adl.core.models import DispatchChannel, Wis2BoxUpload
+from adl.core.probes import PROBE_COOLDOWN_SECONDS, PROBE_WALL_CLOCK_SECONDS
+from adl.core.views import dispatch_test_cooldown_key
 from .factories import Wis2BoxUploadFactory
 
 
@@ -116,6 +121,81 @@ class RunDispatchConnectionTestTests(TestCase):
         self.assertIn("client blew up", result["message"])
 
 
+class DispatchProbeWallClockTests(TestCase):
+    """A channel lives in a plugin repo that upgrades on its own schedule, so
+    the ~10 s in the base-class docstring is a contract, not a guarantee.
+    `adl-s3-plugin` inherits boto3's 60 s connect + 60 s read + retries."""
+
+    def setUp(self):
+        self.channel = Wis2BoxUploadFactory()
+        self.release = threading.Event()
+        self.addCleanup(self.release.set)
+
+    def blocking_probe(self, *args, **kwargs):
+        self.release.wait(30)
+        return {"ok": True, "supported": True, "message": "eventually", "latency_ms": 1}
+
+    def test_the_default_budget_is_the_shared_wall_clock(self):
+        """The same number on both sides, so the worst case an operator can
+        experience is identical whichever button they press."""
+        import inspect
+
+        default = inspect.signature(run_dispatch_connection_test).parameters[
+            "timeout_seconds"].default
+
+        self.assertEqual(default, PROBE_WALL_CLOCK_SECONDS)
+
+    def test_a_blocking_probe_reports_a_failure_naming_the_budget(self):
+        with patch.object(Wis2BoxUpload, "test_connection", self.blocking_probe):
+            result = run_dispatch_connection_test(self.channel, timeout_seconds=0.1)
+
+        self.assertFalse(result["ok"])
+        # `supported` stays True so the admin renders it as an error, not the
+        # softer "not supported for this channel type"
+        self.assertTrue(result["supported"])
+        self.assertIn("0.1-second budget", result["message"])
+        self.assertIn("Wis2BoxUpload", result["message"])
+
+    def test_the_reported_latency_is_measured_not_the_budget_constant(self):
+        with patch.object(Wis2BoxUpload, "test_connection", self.blocking_probe):
+            result = run_dispatch_connection_test(self.channel, timeout_seconds=0.1)
+
+        # Whatever was observed, not 100 assumed — honest if the bound ever
+        # fires early
+        self.assertIsInstance(result["latency_ms"], int)
+        self.assertGreaterEqual(result["latency_ms"], 0)
+
+    def test_the_bound_covers_client_construction_not_just_the_final_call(self):
+        """The live s3 case: `S3Client.__init__` dials `head_bucket`, so the
+        channel blocks before `test_connection`'s own call is reached."""
+
+        def probe_blocking_in_get_client(*args, **kwargs):
+            self.release.wait(30)  # stands in for the eager client constructor
+            raise AssertionError("the destination-facing call is never reached")
+
+        with patch.object(Wis2BoxUpload, "test_connection", probe_blocking_in_get_client):
+            result = run_dispatch_connection_test(self.channel, timeout_seconds=0.1)
+
+        self.assertFalse(result["ok"])
+        self.assertIn("budget", result["message"])
+
+    def test_an_abandoned_worker_does_not_extend_the_callers_wall_clock(self):
+        """Fails if the executor were tidied up into a context manager:
+        `with`-exit joins abandoned workers, so the caller would block until
+        the stuck probe finished rather than returning at the bound."""
+        started = time.monotonic()
+
+        with patch.object(Wis2BoxUpload, "test_connection", self.blocking_probe):
+            run_dispatch_connection_test(self.channel, timeout_seconds=0.1)
+
+        elapsed = time.monotonic() - started
+
+        # The worker is still blocked on `self.release` right now — the wait
+        # is 30 s and the caller is already back
+        self.assertFalse(self.release.is_set())
+        self.assertLess(elapsed, 5)
+
+
 class Wis2BoxTestConnectionTests(TestCase):
     def setUp(self):
         self.channel = Wis2BoxUploadFactory()
@@ -151,6 +231,7 @@ class Wis2BoxTestConnectionTests(TestCase):
 
 class TestConnectionAdminViewTests(TestCase):
     def setUp(self):
+        cache.clear()
         self.channel = Wis2BoxUploadFactory()
         self.user = get_user_model().objects.create_superuser(
             username="admin", email="admin@example.com", password="test-pass"
@@ -185,3 +266,153 @@ class TestConnectionAdminViewTests(TestCase):
 
         mock_probe.assert_not_called()
         self.assertIn("login", response["Location"])
+
+    def test_a_blocking_channel_still_completes_the_request_as_an_error(self):
+        """End to end: the operator gets a rendered error inside the budget
+        rather than a wedged worker."""
+        release = threading.Event()
+        self.addCleanup(release.set)
+
+        def blocking_probe(*args, **kwargs):
+            release.wait(30)
+            return {"ok": True, "supported": True, "message": "late", "latency_ms": 1}
+
+        with patch.object(Wis2BoxUpload, "test_connection", blocking_probe), \
+                patch("adl.core.views.run_dispatch_connection_test",
+                      side_effect=lambda channel: run_dispatch_connection_test(
+                          channel, timeout_seconds=0.1)):
+            response = self.client.post(
+                self.url, HTTP_REFERER="/admin/dispatch-channels/", follow=True
+            )
+
+        rendered = [str(m) for m in response.context["messages"]]
+        self.assertTrue(any("budget" in m for m in rendered), rendered)
+        self.assertFalse(release.is_set())
+
+
+class TestConnectionCooldownTests(TestCase):
+    """The wall clock bounds a single press; nothing bounds ten of them. The
+    cooldown is claimed before the probe fires, mirroring the source probe."""
+
+    def setUp(self):
+        cache.clear()
+        self.channel = Wis2BoxUploadFactory()
+        self.user = get_user_model().objects.create_superuser(
+            username="admin", email="admin@example.com", password="test-pass"
+        )
+        self.client.force_login(self.user)
+        self.url = reverse("dispatch_channel_test_connection", args=[self.channel.id])
+        self.ok_result = {
+            "ok": True, "supported": True, "message": "reachable", "latency_ms": 12,
+        }
+
+    def press(self):
+        # Redirect back to a real admin page, so the assertions below read
+        # the rendered messages off a 200 rather than an error page
+        return self.client.post(
+            self.url, HTTP_REFERER=reverse("wagtailadmin_home"), follow=True
+        )
+
+    def test_a_second_press_inside_the_cooldown_does_not_dial_the_destination(self):
+        with patch.object(Wis2BoxUpload, "test_connection",
+                          return_value=self.ok_result) as probe:
+            self.press()
+            response = self.press()
+
+        self.assertEqual(probe.call_count, 1)
+        self.assertEqual(response.status_code, 200)
+
+        rendered = [str(m) for m in response.context["messages"]]
+        self.assertTrue(any("second(s) ago" in m for m in rendered), rendered)
+
+    def test_a_press_inside_the_cooldown_is_a_message_not_an_error(self):
+        with patch.object(Wis2BoxUpload, "test_connection", return_value=self.ok_result):
+            self.press()
+            response = self.press()
+
+        levels = {m.level_tag for m in response.context["messages"]}
+        self.assertNotIn("error", levels)
+        self.assertIn("info", levels)
+
+    def test_a_raising_probe_does_not_release_the_cooldown(self):
+        """The destination was dialled either way, so the budget is spent."""
+        with patch.object(Wis2BoxUpload, "test_connection",
+                          side_effect=RuntimeError("boom")) as probe:
+            self.press()
+            self.press()
+
+        self.assertEqual(probe.call_count, 1)
+
+    def test_completion_does_not_extend_or_release_the_cooldown_ttl(self):
+        key = dispatch_test_cooldown_key(self.channel)
+
+        with patch.object(Wis2BoxUpload, "test_connection", return_value=self.ok_result), \
+                patch.object(cache, "set") as cache_set, \
+                patch.object(cache, "touch", create=True) as cache_touch, \
+                patch.object(cache, "delete") as cache_delete:
+            self.press()
+            claim_after_first = cache.get(key)
+            self.press()
+
+        self.assertIsNotNone(claim_after_first)
+        self.assertEqual(cache.get(key), claim_after_first)
+
+        # The claim is written once, with `add`, before the probe fires and
+        # is never touched again: no set/touch/delete may follow it, which is
+        # what would extend (or release) the TTL. Unrelated admin-render
+        # caching is ignored — only this key matters
+        for mock in (cache_set, cache_touch, cache_delete):
+            touched_keys = [call.args[0] for call in mock.call_args_list if call.args]
+            self.assertNotIn(key, touched_keys)
+
+    def test_a_channel_with_no_test_of_its_own_never_spends_a_budget(self):
+        """The base implementation returns its verdict without going near the
+        network, so pressing it costs nothing and must keep answering. Burning
+        a budget here would tell the operator to wait instead of telling them
+        again that this channel type has no test."""
+        bare = DispatchChannel.objects.create(name="Bare Channel")
+        url = reverse("dispatch_channel_test_connection", args=[bare.id])
+
+        first = self.client.post(url, HTTP_REFERER=reverse("wagtailadmin_home"), follow=True)
+        second = self.client.post(url, HTTP_REFERER=reverse("wagtailadmin_home"), follow=True)
+
+        for response in (first, second):
+            rendered = [str(m) for m in response.context["messages"]]
+            self.assertTrue(any("not supported" in m for m in rendered), rendered)
+            self.assertFalse(any("second(s) ago" in m for m in rendered), rendered)
+
+    def test_the_cooldown_message_names_the_actual_cooldown(self):
+        with patch.object(Wis2BoxUpload, "test_connection", return_value=self.ok_result):
+            self.press()
+            response = self.press()
+
+        rendered = " ".join(str(m) for m in response.context["messages"])
+        self.assertIn(f"every {PROBE_COOLDOWN_SECONDS} seconds", rendered)
+
+    def test_an_unreadable_claim_reports_no_age_rather_than_a_made_up_one(self):
+        key = dispatch_test_cooldown_key(self.channel)
+        cache.add(key, "not-a-timestamp", timeout=PROBE_COOLDOWN_SECONDS)
+
+        with patch.object(Wis2BoxUpload, "test_connection") as probe:
+            response = self.press()
+
+        probe.assert_not_called()
+        rendered = " ".join(str(m) for m in response.context["messages"])
+        self.assertIn("moments ago", rendered)
+        self.assertNotIn("0 second(s)", rendered)
+
+    def test_each_channel_gets_its_own_budget(self):
+        other = Wis2BoxUploadFactory()
+
+        self.assertNotEqual(dispatch_test_cooldown_key(self.channel),
+                            dispatch_test_cooldown_key(other))
+
+        with patch.object(Wis2BoxUpload, "test_connection",
+                          return_value=self.ok_result) as probe:
+            self.press()
+            self.client.post(
+                reverse("dispatch_channel_test_connection", args=[other.id]),
+                HTTP_REFERER=reverse("wagtailadmin_home"), follow=True,
+            )
+
+        self.assertEqual(probe.call_count, 2)

--- a/adl/src/adl/core/tests/test_source_checks.py
+++ b/adl/src/adl/core/tests/test_source_checks.py
@@ -7,11 +7,15 @@ The probe never dials a real host in tests — DNS and TCP sit behind the
 module's ``socket`` reference and are patched there.
 """
 
+import inspect
 import socket
+import threading
+import time
 from unittest.mock import patch
 
 from django.test import TestCase
 
+from adl.core import probes, source_checks
 from adl.core.source_checks import (
     CHECK_DNS,
     CHECK_SOURCE,
@@ -312,3 +316,90 @@ class StationCheckRunTests(TestCase):
 
         self.assertEqual(step.result.status, SourceCheckStatus.FAILED)
         self.assertIn("did not complete", step.result.message)
+
+
+class SharedProbePrimitiveTests(TestCase):
+    """The wall clock and the executor discipline behind it have one home
+    (:mod:`adl.core.probes`), shared with the dispatch side. A second copy is
+    where the abandon-don't-join discipline would silently come back as a
+    tidy-up."""
+
+    def test_the_wall_clock_constant_is_the_shared_one(self):
+        self.assertIs(source_checks.PROBE_WALL_CLOCK_SECONDS,
+                      probes.PROBE_WALL_CLOCK_SECONDS)
+
+    def test_source_checks_builds_no_thread_pool_of_its_own(self):
+        """Pins the "no second copy of the executor discipline" criterion at
+        the only place it can be checked: a pool built here would be a pool
+        whose abandon-don't-join rule is remembered twice."""
+        self.assertNotIn("ThreadPoolExecutor", inspect.getsource(source_checks))
+
+    def test_the_shared_pool_is_never_joined_on_exit(self):
+        """Fails if `bounded_executor` were written as
+        `with ThreadPoolExecutor(...)`: `with`-exit joins abandoned workers,
+        so a stuck step would outlive the bound the module promises."""
+        with patch("adl.core.probes.ThreadPoolExecutor") as pool:
+            with probes.bounded_executor(2):
+                pass
+
+        pool.return_value.shutdown.assert_called_once_with(wait=False)
+        pool.return_value.__exit__.assert_not_called()
+
+    def test_an_abandoned_worker_does_not_extend_the_probes_wall_clock(self):
+        release = threading.Event()
+        self.addCleanup(release.set)
+
+        def stuck():
+            release.wait(30)
+            return SourceCheckResult(status=SourceCheckStatus.OK)
+
+        connection = NetworkConnectionFactory()
+        connection.check_source = stuck
+
+        started = time.monotonic()
+        steps = run_source_probe(connection, timeout_seconds=0.05)
+        elapsed = time.monotonic() - started
+
+        self.assertEqual(steps[0].result.status, SourceCheckStatus.FAILED)
+        self.assertFalse(release.is_set())
+        self.assertLess(elapsed, 5)
+
+    def test_the_station_check_shares_the_same_bound(self):
+        release = threading.Event()
+        self.addCleanup(release.set)
+
+        link = StationLinkFactory()
+        link.check_station_source = lambda: release.wait(30)
+
+        started = time.monotonic()
+        step = run_station_source_check(link, timeout_seconds=0.05)
+        elapsed = time.monotonic() - started
+
+        self.assertEqual(step.result.status, SourceCheckStatus.FAILED)
+        self.assertFalse(release.is_set())
+        self.assertLess(elapsed, 5)
+
+
+class ProbeTimeoutTests(TestCase):
+    """The bound's expiry has its own exception type. Since Python 3.11 the
+    executor's TimeoutError *is* the builtin TimeoutError, so a shared type
+    would report a call that failed fast with its own socket timeout as one
+    that never completed."""
+
+    def test_the_bound_raises_its_own_type_on_expiry(self):
+        with self.assertRaises(probes.ProbeTimeout):
+            probes.run_bounded(lambda: time.sleep(5), 0.01)
+
+    def test_a_callee_raising_timeout_error_is_not_reported_as_the_bound(self):
+        def fails_fast():
+            raise TimeoutError("the destination timed out on its own terms")
+
+        connection = NetworkConnectionFactory()
+        connection.check_source = fails_fast
+
+        steps = run_source_probe(connection, timeout_seconds=5)
+
+        result = steps[0].result
+        self.assertEqual(result.status, SourceCheckStatus.FAILED)
+        self.assertIn("TimeoutError", result.message)
+        self.assertNotIn("did not complete", result.message)

--- a/adl/src/adl/core/views.py
+++ b/adl/src/adl/core/views.py
@@ -7,6 +7,7 @@ from django.core.paginator import Paginator, InvalidPage
 from django.db import transaction
 from django.shortcuts import render, redirect, get_object_or_404
 from django.urls import reverse_lazy, reverse
+from django.utils import timezone as dj_timezone
 from django.utils.translation import gettext as _
 from django.views.decorators.http import (
     require_http_methods,
@@ -30,7 +31,10 @@ from .constants import (
     OSCAR_SURFACE_REQUIRED_CSV_COLUMNS,
     PREDEFINED_DATA_PARAMETERS
 )
-from .dispatch_checks import run_dispatch_connection_test
+from .dispatch_checks import (
+    channel_implements_test_connection,
+    run_dispatch_connection_test
+)
 from .forms import (
     StationLoaderForm,
     OSCARStationImportForm,
@@ -49,6 +53,11 @@ from .models import (
     StationLink, Network
 )
 from .plugin_utils import get_plugin_metadata
+from .probes import (
+    PROBE_COOLDOWN_SECONDS,
+    claim_probe_cooldown,
+    read_probe_claim
+)
 from .registries import (
     dispatch_channel_viewset_registry,
     connection_viewset_registry,
@@ -1341,17 +1350,79 @@ def reset_channel_dispatch(request, channel_id):
     return redirect('wagtailadmin_home')
 
 
+def dispatch_test_cooldown_key(channel):
+    """The cooldown cache key for one dispatch channel's connection test.
+
+    Keyed on the channel id rather than the destination host: a channel's
+    destination is a plugin-private detail with no contract for reading it,
+    unlike the ingestion side's ``get_source_endpoint()``. Two channels
+    pointing at the same host therefore get a budget each — a looser bound
+    than the source probe's, but still one that a repeated press cannot
+    exceed.
+    """
+    return f"adl_dispatch_test_cooldown:channel:{channel.id}"
+
+
+def _report_existing_dispatch_test(request, claimed_at, now):
+    """A press inside the cooldown: an informational answer about the press
+    already made, never an error and never a second dial.
+
+    Unlike the ingestion diagnostic, there is no stored history to hand back
+    — a dispatch test's verdict lives only in the message it produced — so
+    the honest answer is the age of the press that took the budget, and a
+    retry window. A claim that has expired or cannot be read between the
+    failed add and the read is reported without an age rather than with a
+    made-up one.
+    """
+    if claimed_at is None:
+        messages.info(
+            request,
+            _('This channel was tested moments ago. One test per channel '
+              'every %(cooldown)d seconds — try again shortly.')
+            % {'cooldown': PROBE_COOLDOWN_SECONDS},
+        )
+        return
+
+    messages.info(
+        request,
+        _('This channel was tested %(seconds)d second(s) ago. One test per '
+          'channel every %(cooldown)d seconds — try again shortly.')
+        % {'seconds': max(int((now - claimed_at).total_seconds()), 0),
+           'cooldown': PROBE_COOLDOWN_SECONDS},
+    )
+
+
 def test_dispatch_channel_connection(request, channel_id):
     """Synchronously probe a dispatch channel's destination.
 
     Runs in the web process on purpose: a wedged dispatch queue must not be
     able to mask a destination health check.
 
-    The probe is an out-of-core plugin's code, so its return goes through
-    ``run_dispatch_connection_test`` rather than being read directly.
+    The probe is an out-of-core plugin's code, so neither its return nor its
+    latency is trusted: ``run_dispatch_connection_test`` normalises the one
+    and bounds the other.
+
+    The bound covers a single press. The cooldown below covers ten of them:
+    claimed **before** the probe fires, never extended on completion and
+    never released early — including when the probe raises, since a crashed
+    probe still dialled the destination. So a press inside the cooldown
+    always resolves to a message, never an error and never a second thread
+    against a dead host.
+
+    A channel that does not implement the contract is exempt: its press
+    cannot dial anything, so it must not spend a budget — otherwise the
+    operator's second press would be told to wait instead of being told
+    again that the channel type has no test.
     """
     if request.method == 'POST':
         dispatch_channel = get_object_or_404(DispatchChannel, id=channel_id)
+
+        now = dj_timezone.now()
+        cooldown_key = dispatch_test_cooldown_key(dispatch_channel)
+        if (channel_implements_test_connection(dispatch_channel)
+                and not claim_probe_cooldown(cooldown_key, now)):
+            _report_existing_dispatch_test(request, read_probe_claim(cooldown_key), now)
+            return redirect(request.META.get('HTTP_REFERER', 'wagtailadmin_home'))
 
         result = run_dispatch_connection_test(dispatch_channel)
 

--- a/adl/src/adl/monitoring/views/health.py
+++ b/adl/src/adl/monitoring/views/health.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import logging
 
@@ -18,6 +18,7 @@ from adl.core.broker import (
     tested_range_display,
 )
 from adl.core.models import NetworkConnection, StationLink
+from adl.core.probes import claim_probe_cooldown, read_probe_claim
 from adl.core.tasks import INGESTION_QUEUE_NAME, run_network_plugin
 from adl.core.source_checks import (
     SourceCheckStatus,
@@ -35,11 +36,13 @@ from ..models import (
 
 logger = logging.getLogger(__name__)
 
-# One probe per source host per minute — beneath the noise floor of the
-# ingestion already hitting that host. Deliberately different from the
-# evaluator's 15-minute freshness window: equalising them would make an
-# operator wait 15 minutes to verify a password fix.
-PROBE_COOLDOWN_SECONDS = 60
+# The probe cooldown itself — one press per target per minute, claimed
+# before the dial — lives in `adl.core.probes`, shared with the dispatch
+# side's test-connection button. Here it means one probe per source host per
+# minute, beneath the noise floor of the ingestion already hitting that host,
+# and is deliberately different from the evaluator's 15-minute freshness
+# window: equalising them would make an operator wait 15 minutes to verify a
+# password fix.
 
 # The permission that gates the probe: someone who can edit a host and its
 # credentials can already make the runtime dial them, and a new permission
@@ -227,13 +230,6 @@ def connection_health(request, connection_id):
     return render(request, "monitoring/connection_health.html", context=context)
 
 
-def _parse_claim(value):
-    try:
-        return datetime.fromisoformat(value)
-    except (TypeError, ValueError):
-        return None
-
-
 def connection_probe_source(request, connection_id):
     """
     Fire the on-demand source probe (layers 4-5) for one connection —
@@ -266,8 +262,8 @@ def connection_probe_source(request, connection_id):
 
     now = dj_timezone.now()
     key = source_probe_cooldown_key(connection)
-    if not cache.add(key, now.isoformat(), timeout=PROBE_COOLDOWN_SECONDS):
-        _report_existing_probe(request, connection, cache.get(key), now)
+    if not claim_probe_cooldown(key, now):
+        _report_existing_probe(request, connection, read_probe_claim(key), now)
         return diagnostic_page
 
     try:
@@ -300,11 +296,10 @@ def connection_probe_source(request, connection_id):
     return diagnostic_page
 
 
-def _report_existing_probe(request, connection, claim, now):
+def _report_existing_probe(request, connection, claimed_at, now):
     """A press inside the cooldown: the shared result is the limit, so the
     answer is the stored result (with its age and origin) or the in-flight
     state — never a refusal."""
-    claimed_at = _parse_claim(claim)
     newest = (SourceProbeResult.objects
               .filter(connection=connection, station_link__isnull=True)
               .order_by("-at")
@@ -401,7 +396,7 @@ def connection_run_now(request, connection_id):
     key = manual_run_cooldown_key(connection)
     if not cache.add(key, now.isoformat(),
                      timeout=manual_run_cooldown_seconds(connection)):
-        claimed_at = _parse_claim(cache.get(key))
+        claimed_at = read_probe_claim(key)
         minutes = probe_age_minutes(now, claimed_at) if claimed_at else 0
         messages.info(
             request,
@@ -469,8 +464,8 @@ def station_link_check_source(request, link_id):
 
     now = dj_timezone.now()
     key = station_source_check_cooldown_key(station_link)
-    if not cache.add(key, now.isoformat(), timeout=PROBE_COOLDOWN_SECONDS):
-        _report_existing_station_check(request, station_link, cache.get(key), now)
+    if not claim_probe_cooldown(key, now):
+        _report_existing_station_check(request, station_link, read_probe_claim(key), now)
         return inspect_page
 
     try:
@@ -503,11 +498,10 @@ def station_link_check_source(request, link_id):
     return inspect_page
 
 
-def _report_existing_station_check(request, station_link, claim, now):
+def _report_existing_station_check(request, station_link, claimed_at, now):
     """A press inside the cooldown: the shared result is the limit, so the
     answer is this station's own stored result (with its age and origin) or
     the in-flight state — never a refusal."""
-    claimed_at = _parse_claim(claim)
     newest = (SourceProbeResult.objects
               .filter(station_link=station_link)
               .order_by("-at")


### PR DESCRIPTION
Closes #211.

`test_dispatch_channel_connection` runs the probe synchronously in the web process on purpose — a wedged dispatch queue must not be able to mask a destination health check — but nothing bounded how long a channel could take, and nothing bounded how often the button could be pressed.

The only thing standing behind the base-class docstring's "~10 seconds" was the honour system, against code that lives in independently-versioned plugin repos. `adl-s3-plugin` builds its boto3 client with no `botocore.Config` (60 s connect + 60 s read + retries) and dials `head_bucket` from `__init__`, so a blackholed endpoint tied up a Daphne worker for minutes per click — and the button was re-clickable.

## What changed

**`core/probes.py` (new)** — the one home for the wall clock (`PROBE_WALL_CLOCK_SECONDS = 15`), the press budget (`PROBE_COOLDOWN_SECONDS = 60`), the executor discipline behind the bound, and the cooldown claim/read pair. Provider-neutral: none of it is ingestion-specific, and a private cross-import would have made `source_checks` the de facto owner of a shared primitive.

The discipline that must not regress is one line of *absence* — the pool is shut down with `wait=False` and never entered as a context manager, because `with`-exit joins abandoned workers and would let a stuck plugin outlive the bound. `bounded_executor` encapsulates it so no second copy exists, and a test fails if it were ever tidied into a `with`.

**`dispatch_checks`** — `run_dispatch_connection_test` runs the channel under the bound. A timeout returns the same dict shape a malformed return does (`supported=True`, so the admin takes its error branch), naming the budget and reporting the *measured* elapsed time rather than the constant. The bound covers the whole call, so the s3 case that blocks in the client constructor is caught.

**`core/views.py`** — the button claims a per-channel cooldown atomically *before* dialling, never extended on completion and never released early (a crashed probe still dialled the destination). A press inside the cooldown resolves to an info message, never an error.

**`source_checks` + `monitoring/views/health.py`** — moved onto the shared primitives: one wall clock, one claim/read pair, no second `_parse_claim`.

**Docs** — `dispatch_checks` and the `models.py` base-class docstring now describe what core enforces rather than what implementations are asked to promise. The ~10 s stays the contract; the 15 s wall is only what happens when it is broken.

## Two departures from the ticket, deliberate

- The ticket said `source_checks` "keeps its own two-worker executor". The pool moved into `bounded_executor` instead, because the acceptance criterion *"no second copy of the executor discipline exists"* is the stronger constraint. It rewrote six ingestion-side signatures — larger than the ticket authorised, though behaviour-neutral and covered by the existing tests.
- `ProbeTimeout` is its own exception type rather than `concurrent.futures.TimeoutError`. Since Python 3.11 that **is** the builtin `TimeoutError`, so sharing it would report a channel that failed fast with its own socket timeout as one that never completed. The worker's outcome is boxed so the only exception the wait can raise is a real expiry.

## Out of scope (per the ticket)

- Fixing `adl-s3-plugin`'s missing `botocore.Config` timeouts — the point here is that core should not depend on 21 sibling repos each getting it right.
- The missing permission check on this view (#163). The cooldown is **not** a substitute for that gate.
- The `(bounded_call, deadline, timeout_seconds)` clump threading through five `source_checks` functions — pre-existing shape, further out of scope than this already went.

## Testing

451 tests pass (`make dev-test`). New coverage: the bound and its failure dict, that it covers `get_client()`-style work, that an abandoned worker cannot extend the caller's wall clock (fails if the executor were a context manager), the single-home constant, `ProbeTimeout` vs. a fast-failing callee, the cooldown's claim-before-probe ordering and TTL behaviour, and the unsupported-channel exemption.