### PR TITLE
fix: redact credentials from operator-visible failure text

### DIFF
--- a/.claude/docs/architectural_patterns.md
+++ b/.claude/docs/architectural_patterns.md
@@ -43,6 +43,20 @@ in both directions). A plugin that knows what its exception means may pre-stamp 
 `FAILURE_CATEGORIES` and drops bad values; unknown/ambiguous types are declined (`NULL`), never guessed. An attribute
 rather than a core exception class so plugins keep importing cleanly against older core.
 
+**Secret redaction at the write point:** the same failure write points pass their text through `redact_secrets()`
+(`adl/core/redaction.py`) before it is stored. `requests` puts the full request URL in its `HTTPError` text, so a
+source that authenticates with a query parameter turns a 401 into a stored, API-served copy of its own token.
+Redaction is done where the text is produced, not at the serializer, because the row is also rendered in the admin,
+exported and echoed into worker logs — one call bounds the exposure instead of every new reader having to remember.
+Only *named* secrets go (`token=***`, `Bearer ***`, `scheme://***:***@host`); the key is kept so the message still
+says which credential was involved. Plugins do not call it — core redacts a plugin's `SourceCheckResult.message` and
+`test_connection()` message on their way in, and `TaskLogger` redacts every line it pushes to the SSE stream. One
+surface has no core write point at all — Celery, not core, writes a failing task's text and traceback — so
+`TaskResultSerializer` redacts it on read with `redact_json()`/`redact_secrets()`. Worker-log tracebacks (`exc_info`)
+are deliberately not stripped — a host-local log is not a shared surface, and the traceback is why the entry exists.
+`mark_failed()` in `classification.py` is the one call that ends a failed run (status, success, redacted message,
+classification stamps) so a new write point cannot forget a step.
+
 New plugins are scaffolded using the Cookiecutter template in `plugin-boilerplate/`.
 
 ## 3. Polymorphic Models

--- a/adl/src/adl/core/classification.py
+++ b/adl/src/adl/core/classification.py
@@ -114,3 +114,25 @@ def stamp_failure(activity_log, exc) -> None:
     category, layer = classify_failure(exc)
     activity_log.error_category = category
     activity_log.error_layer = layer
+
+
+def mark_failed(activity_log, exc) -> str:
+    """
+    Record ``exc`` as the failure that ended this run, and return the text.
+
+    The whole terminal-failure gesture in one call — status, success flag,
+    redacted message, classification stamps — because it was previously
+    repeated at each write point, and every copy was a place a later one
+    could forget to redact. Callers that want to log the text get it back
+    rather than reaching into the (unsaved) log instance for it.
+    """
+    from adl.monitoring.models import StationLinkActivityLog
+
+    from .redaction import redact_secrets
+
+    message = redact_secrets(exc)
+    activity_log.success = False
+    activity_log.message = message
+    activity_log.status = StationLinkActivityLog.ActivityStatus.FAILED
+    stamp_failure(activity_log, exc)
+    return message

--- a/adl/src/adl/core/dispatch_checks.py
+++ b/adl/src/adl/core/dispatch_checks.py
@@ -29,6 +29,7 @@ from collections.abc import Mapping
 from django.utils.translation import gettext as _
 
 from .probes import PROBE_WALL_CLOCK_SECONDS, ProbeTimeout, run_bounded
+from .redaction import redact_secrets
 
 logger = logging.getLogger(__name__)
 
@@ -92,7 +93,10 @@ def normalise_dispatch_test_result(value, channel_type=None, measured_ms=None):
     return {
         "ok": bool(value["ok"]),
         "supported": bool(value["supported"]),
-        "message": str(value["message"]),
+        # Redacted here rather than at each channel: a plugin's own failure
+        # text is the likeliest place for a destination credential to appear,
+        # and no channel can be relied on to strip it.
+        "message": redact_secrets(str(value["message"])),
         "latency_ms": _coerce_latency(value.get("latency_ms"), measured_ms),
     }
 
@@ -146,7 +150,7 @@ def run_dispatch_connection_test(channel, timeout_seconds=PROBE_WALL_CLOCK_SECON
             "ok": False,
             "supported": True,
             "message": _("The connection test raised %(type)s: %(error)s")
-                       % {"type": type(e).__name__, "error": e},
+                       % {"type": type(e).__name__, "error": redact_secrets(e)},
             "latency_ms": elapsed_ms(),
         }
 

--- a/adl/src/adl/core/dispatchers/__init__.py
+++ b/adl/src/adl/core/dispatchers/__init__.py
@@ -1,7 +1,7 @@
 import logging
 import time
 
-from adl.core.classification import stamp_failure
+from adl.core.classification import mark_failed
 from adl.core.utils import get_object_or_none
 from adl.monitoring.models import StationLinkActivityLog
 from django.utils import timezone as dj_timezone
@@ -328,12 +328,9 @@ def run_dispatch_channel(dispatcher_id, station_link_ids=None):
             log.message = f"Sent {num_of_sent_records} records successfully."
         
         except Exception as e:
-            log.success = False
-            log.message = str(e)
-            log.status = StationLinkActivityLog.ActivityStatus.FAILED
-            stamp_failure(log, e)
+            message = mark_failed(log, e)
             logger.error(f"[DISPATCH] Error while sending data for station {station_link} on channel "
-                         f"{dispatch_channel.name}: {e}")
+                         f"{dispatch_channel.name}: {message}")
         finally:
             log.duration_ms = (time.monotonic() - start) * 1000
             log.save()

--- a/adl/src/adl/core/logging.py
+++ b/adl/src/adl/core/logging.py
@@ -4,6 +4,8 @@ from typing import Optional
 
 from django_eventstream import send_event
 
+from .redaction import redact_secrets
+
 logger = logging.getLogger(__name__)
 
 
@@ -25,10 +27,20 @@ class TaskLogger:
             logger.debug(f"TaskLogger initialized: task_id={task_id}, plugin={plugin_label}")
     
     def _send_to_stream(self, message: str, level: str = 'info'):
-        """Send log message to SSE stream via django-eventstream"""
+        """
+        Send log message to SSE stream via django-eventstream.
+
+        Redacted on the way out, not on the way in: the local logger keeps
+        the message a plugin actually wrote, while what leaves the process
+        for a browser carries no credential. Plugins interpolate exceptions
+        into their log lines freely, so this is the only place the stream
+        can be bounded.
+        """
         if not self.task_id:
             return
-        
+
+        message = redact_secrets(message)
+
         try:
             # Send event to task-specific channel
             send_event(

--- a/adl/src/adl/core/redaction.py
+++ b/adl/src/adl/core/redaction.py
@@ -1,0 +1,160 @@
+"""
+Write-time secret redaction for operator-visible failure text.
+
+An exception's ``str()`` is the richest thing a failed run can record, and
+it is also where credentials escape: ``requests`` puts the full request URL
+in its ``HTTPError`` text, so a source that authenticates with a query
+parameter — several plugins do — turns a 401 into a stored, API-served copy
+of its own token.
+
+Redaction happens **at the write point**, not at the serializer. The stored
+row is not the only surface: activity logs are rendered in the Wagtail
+admin, exported, and echoed into worker logs, and each new reader would
+otherwise have to remember to redact. Redacting once, where the text is
+produced, bounds the exposure instead of chasing it. The cost is that the
+secret is unrecoverable from the row — which is the point; the value of a
+credential is never the diagnostic part of the message.
+
+One surface cannot follow that rule: ``django_celery_results`` writes a
+failing task's exception text and traceback itself, so core has no write
+point to redact at and ``TaskResultSerializer`` redacts on read instead.
+That is the exception, and it is named there.
+
+The patterns are deliberately narrow. Only a *named* secret is removed —
+a key whose name ends in a sensitive word, or an HTTP authorization scheme
+— and the key itself is kept, so the message still says which credential
+was involved. Free text that merely looks random is left alone: over-eager
+masking destroys the error text operators depend on.
+"""
+
+import re
+
+__all__ = ["REDACTED", "redact_json", "redact_secrets"]
+
+REDACTED = "***"
+
+# A parameter/field name is sensitive when it *ends* in one of these words,
+# so ``api_key``, ``x-api-key``, ``client_secret`` and ``ACCESS_TOKEN`` are
+# all covered without enumerating every vendor's spelling.
+SENSITIVE_SUFFIXES = (
+    "tokens?",
+    "keys?",
+    "secrets?",
+    "passwords?",
+    "passwd",
+    "pwd",
+    "credentials?",
+    "authorization",
+    "auth",
+    "signature",
+    "sig",
+)
+
+# HTTP authorization schemes whose following word is the credential itself.
+SCHEME_NAMES = ("Bearer", "Basic", "Token", "Digest")
+
+# Matching on the suffix means an innocent ``sort_key=asc`` is masked too.
+# That is the intended bias: a name is only a hint, and losing a sort order
+# from an error message costs less than keeping a token in one.
+_KEY = r"[A-Za-z0-9_.\-]*(?:" + "|".join(SENSITIVE_SUFFIXES) + r")"
+
+_SCHEMES = r"(?:" + "|".join(SCHEME_NAMES) + r")"
+
+# key <sep> value, where value is a quoted string, a scheme + credential, or
+# a bare run of value characters. The bare form stops at the delimiters that
+# end a value in a query string, a JSON blob or ordinary prose, and may be
+# empty so that ``token=`` is masked rather than left looking untouched.
+_KEY_VALUE_RE = re.compile(
+    r"(?i)"
+    r"\b(?P<key>" + _KEY + r")"
+    # A JSON key ("secret": "…") keeps its own closing quote — it is carried
+    # through in ``sep`` — while the value's quotes go with the value, so the
+    # result reads ``{"secret": ***}``. The output is operator-facing text,
+    # not JSON, and is not required to survive a parser.
+    r"(?P<sep>[\"']?\s*[:=]\s*)"
+    r"(?:\"[^\"]*\"|'[^']*'|" + _SCHEMES + r"\s+\S+|[^\s,;&'\"()<>]*)"
+)
+
+# A bare ``Bearer <credential>`` with no key in front of it.
+_SCHEME_RE = re.compile(r"(?i)\b(?P<scheme>" + _SCHEMES + r")\s+(?P<token>\S+)")
+
+# scheme://user:password@host — the password is in the URL itself.
+_USERINFO_RE = re.compile(r"(?i)\b([a-z][a-z0-9+.\-]*://)[^/\s:@]+:[^/\s@]*@")
+
+# A whole mapping key that names a secret. In parsed data the key and its
+# value are already separate, so the value goes whatever it looks like —
+# there is no text pattern left to recognise it by.
+_SENSITIVE_NAME_RE = re.compile(r"(?i)\A" + _KEY + r"\Z")
+
+_CREDENTIAL_CHARS = set("+/=._~-")
+
+
+def _looks_like_credential(token):
+    """
+    Whether the word after an authorization scheme is plausibly a credential.
+
+    "Basic dXNlcjpwYXNz" is; "Basic connection failed" is not. Prose is all
+    lower case and short-ish, so anything long enough that mixes case, digits
+    or credential punctuation is treated as a secret.
+    """
+    if len(token) < 8 or token == REDACTED:
+        return False
+    if any(character.isdigit() or character in _CREDENTIAL_CHARS for character in token):
+        return True
+    return any(c.islower() for c in token) and any(c.isupper() for c in token)
+
+
+def _mask_scheme(match):
+    token = match.group("token")
+    if not _looks_like_credential(token):
+        return match.group(0)
+    return f"{match.group('scheme')} {REDACTED}"
+
+
+def redact_secrets(text):
+    """
+    Return ``text`` with any named credential replaced by ``***``.
+
+    ``None`` passes through unchanged so callers can redact an optional
+    message without a guard; anything else is coerced with ``str()``, which
+    is what makes ``redact_secrets(exc)`` the natural call at a write point.
+    The function is idempotent: redacting already-redacted text is a no-op.
+    """
+    if text is None:
+        return None
+
+    if not isinstance(text, str):
+        text = str(text)
+
+    text = _USERINFO_RE.sub(rf"\1{REDACTED}:{REDACTED}@", text)
+    text = _KEY_VALUE_RE.sub(rf"\g<key>\g<sep>{REDACTED}", text)
+    text = _SCHEME_RE.sub(_mask_scheme, text)
+
+    return text
+
+
+def redact_json(value):
+    """
+    Return parsed JSON with any credential removed, structure intact.
+
+    Two things happen: a mapping key that *names* a secret loses its value
+    outright — parsed data has already split key from value, so nothing about
+    the value itself would give it away — and every remaining string is run
+    through :func:`redact_secrets` for credentials embedded in text.
+
+    Structure is preserved so a caller reading a task result still finds the
+    keys it expects, with ``***`` where a secret used to be.
+    """
+    if isinstance(value, dict):
+        return {
+            key: REDACTED if _SENSITIVE_NAME_RE.match(str(key)) else redact_json(item)
+            for key, item in value.items()
+        }
+
+    if isinstance(value, list):
+        return [redact_json(item) for item in value]
+
+    if isinstance(value, str):
+        return redact_secrets(value)
+
+    return value

--- a/adl/src/adl/core/registries.py
+++ b/adl/src/adl/core/registries.py
@@ -25,7 +25,7 @@ from celery.exceptions import SoftTimeLimitExceeded
 from django.core.exceptions import ImproperlyConfigured
 from django.utils import timezone as dj_timezone
 
-from .classification import stamp_failure
+from .classification import mark_failed, stamp_failure
 from .date_utils import make_record_timezone_aware
 from .logging import TaskLogger
 from .registry import Registry, Instance
@@ -886,11 +886,7 @@ class Plugin(Instance):
             log.error("Ingestion for station %s timed out", station_link)
             raise
         except Exception as e:
-            error_msg = str(e)
-            activity_log.success = False
-            activity_log.message = error_msg
-            activity_log.status = StationLinkActivityLog.ActivityStatus.FAILED
-            stamp_failure(activity_log, e)
+            error_msg = mark_failed(activity_log, e)
             log.error("Error processing station %s: %s", station_link, error_msg)
         finally:
             activity_log.duration_ms = (time.monotonic() - start) * 1000

--- a/adl/src/adl/core/source_checks.py
+++ b/adl/src/adl/core/source_checks.py
@@ -27,6 +27,7 @@ from typing import Optional, Tuple
 from django.utils.translation import gettext as _
 
 from .classification import FAILURE_CATEGORIES
+from .redaction import redact_secrets
 # The wall clock and the executor discipline behind it are shared with the
 # dispatch side, so one press cannot cost an operator more than the other.
 # This probe spends that one budget across DNS, TCP and the plugin's own
@@ -110,9 +111,11 @@ def normalise_source_check_result(value) -> SourceCheckResult:
             message=_("The plugin returned an unknown status %(status)r.")
                     % {"status": value.status},
         )
-    if value.category is not None and value.category not in FAILURE_CATEGORIES:
-        return replace(value, category=None)
-    return value
+    category = value.category if value.category in FAILURE_CATEGORIES else None
+    # The plugin's own message is persisted and served over the API, and a
+    # plugin that authenticates in a query string will have put its
+    # credential in there — so it is redacted here, once, for every plugin.
+    return replace(value, category=category, message=redact_secrets(value.message))
 
 
 def connection_implements_check_source(connection) -> bool:
@@ -188,7 +191,7 @@ def _dns_step(bounded_call, host, port, deadline) -> ProbeStep:
             status=SourceCheckStatus.FAILED,
             category="DNS_FAILURE",
             message=_("%(host)s did not resolve: %(error)s")
-                    % {"host": host, "error": e},
+                    % {"host": host, "error": redact_secrets(e)},
             latency_ms=_elapsed_ms(started),
         )
     except ProbeTimeout:
@@ -243,7 +246,7 @@ def _tcp_step(bounded_call, host, port, deadline) -> ProbeStep:
             status=SourceCheckStatus.FAILED,
             category="UNKNOWN",
             message=_("A TCP connection to %(host)s:%(port)s failed: %(error)s")
-                    % {**context, "error": e},
+                    % {**context, "error": redact_secrets(e)},
             latency_ms=_elapsed_ms(started),
         )
     else:
@@ -282,7 +285,7 @@ def _plugin_check_step(check_id, check, bounded_call, deadline, timeout_seconds,
         return ProbeStep(check_id, 5, SourceCheckResult(
             status=SourceCheckStatus.FAILED,
             message=_("The source check raised %(type)s: %(error)s")
-                    % {"type": type(e).__name__, "error": e},
+                    % {"type": type(e).__name__, "error": redact_secrets(e)},
             latency_ms=_elapsed_ms(started),
         ))
 

--- a/adl/src/adl/core/tasks.py
+++ b/adl/src/adl/core/tasks.py
@@ -16,9 +16,10 @@ from django.utils import timezone as dj_timezone
 
 from adl.config.celery import app
 from adl.monitoring.models import StationLinkActivityLog
-from .classification import stamp_failure
+from .classification import mark_failed, stamp_failure
 from .dispatchers import get_station_dispatch_records
 from .logging import TaskLogger
+from .redaction import redact_secrets
 from .utils import get_object_or_none
 
 logger = logging.getLogger(__name__)
@@ -394,7 +395,11 @@ def process_station_link_batch(self, network_id, station_link_ids):
                       station_link)
             raise
         except Exception as e:
-            log.error("Error processing station link %s: %s", station_link, str(e), exc_info=True)
+            # The interpolated text is redacted, the traceback deliberately is
+            # not: this line goes only to the worker's own log, where the
+            # traceback is the reason to keep the entry at all. The redaction
+            # is what keeps a shipped-off log line from carrying the token.
+            log.error("Error processing station link %s: %s", station_link, redact_secrets(e), exc_info=True)
             errors += 1
 
         finally:
@@ -635,12 +640,9 @@ def dispatch_station(self, channel_id, station_link_id):
         return {"records_sent": 0, "timed_out": True}
 
     except Exception as e:
-        log.success = False
-        log.message = str(e)
-        log.status = StationLinkActivityLog.ActivityStatus.FAILED
-        stamp_failure(log, e)
+        message = mark_failed(log, e)
         logger.error("[DISPATCH] Error dispatching station %s on channel %s: %s",
-                     station_link, channel.name, e)
+                     station_link, channel.name, message)
         raise
 
     finally:

--- a/adl/src/adl/core/tests/test_redaction.py
+++ b/adl/src/adl/core/tests/test_redaction.py
@@ -1,0 +1,122 @@
+from django.test import SimpleTestCase
+
+from adl.core.redaction import redact_json, redact_secrets
+
+
+class RedactQueryStringTests(SimpleTestCase):
+    def test_redacts_token_query_parameter_in_a_url(self):
+        text = ("401 Client Error: Unauthorized for url: "
+                "https://example.org/data?token=s3cr3t&station=42")
+        self.assertEqual(
+            redact_secrets(text),
+            ("401 Client Error: Unauthorized for url: "
+             "https://example.org/data?token=***&station=42"),
+        )
+
+    def test_redacts_a_first_query_parameter(self):
+        self.assertEqual(
+            redact_secrets("https://example.org/data?api_key=abc123&x=1"),
+            "https://example.org/data?api_key=***&x=1",
+        )
+
+    def test_redacts_compound_key_names(self):
+        for key in ("api_key", "apikey", "x-api-key", "client_secret",
+                    "access_token", "refresh_token", "API_TOKEN", "passwd"):
+            with self.subTest(key=key):
+                self.assertEqual(
+                    redact_secrets(f"https://e.org/?{key}=leaked&n=1"),
+                    f"https://e.org/?{key}=***&n=1",
+                )
+
+    def test_keeps_non_sensitive_query_parameters(self):
+        text = "https://example.org/data?station=42&start=2024-01-01"
+        self.assertEqual(redact_secrets(text), text)
+
+    def test_redacts_every_occurrence(self):
+        self.assertEqual(
+            redact_secrets("?token=a&x=1 and ?token=b&y=2"),
+            "?token=***&x=1 and ?token=***&y=2",
+        )
+
+    def test_redacts_an_empty_valued_secret_parameter(self):
+        self.assertEqual(redact_secrets("?token=&x=1"), "?token=***&x=1")
+
+
+class RedactFreeTextTests(SimpleTestCase):
+    def test_redacts_a_key_value_pair_outside_a_url(self):
+        self.assertEqual(
+            redact_secrets("connect failed (password=hunter2)"),
+            "connect failed (password=***)",
+        )
+
+    def test_redacts_a_colon_separated_pair(self):
+        self.assertEqual(
+            redact_secrets('{"secret": "abc123"}'),
+            '{"secret": ***}',
+        )
+
+    def test_redacts_a_bearer_credential(self):
+        self.assertEqual(
+            redact_secrets("Authorization: Bearer eyJhbGciOi.J9-x_y"),
+            "Authorization: ***",
+        )
+
+    def test_redacts_a_basic_credential(self):
+        self.assertEqual(
+            redact_secrets("sent Basic dXNlcjpwYXNz to host"),
+            "sent Basic *** to host",
+        )
+
+    def test_leaves_ordinary_prose_alone(self):
+        text = "Station 42 returned no records between 10:00 and 11:00."
+        self.assertEqual(redact_secrets(text), text)
+
+
+class RedactUrlUserinfoTests(SimpleTestCase):
+    def test_redacts_userinfo_credentials(self):
+        self.assertEqual(
+            redact_secrets("ftp://alice:hunter2@ftp.example.org/in/"),
+            "ftp://***:***@ftp.example.org/in/",
+        )
+
+    def test_leaves_a_url_without_userinfo_alone(self):
+        text = "https://example.org:8443/data"
+        self.assertEqual(redact_secrets(text), text)
+
+
+class RedactEdgeCaseTests(SimpleTestCase):
+    def test_none_passes_through(self):
+        self.assertIsNone(redact_secrets(None))
+
+    def test_empty_string_passes_through(self):
+        self.assertEqual(redact_secrets(""), "")
+
+    def test_non_string_is_coerced(self):
+        self.assertEqual(redact_secrets(ValueError("token=abc")), "token=***")
+
+
+class RedactJsonTests(SimpleTestCase):
+    def test_a_key_that_names_a_secret_loses_its_value(self):
+        self.assertEqual(
+            redact_json({"api_key": "abc123", "station": 42}),
+            {"api_key": "***", "station": 42},
+        )
+
+    def test_nested_structures_are_walked(self):
+        self.assertEqual(
+            redact_json({"errors": [{"password": "hunter2"}, {"code": 401}]}),
+            {"errors": [{"password": "***"}, {"code": 401}]},
+        )
+
+    def test_secrets_embedded_in_string_values_are_redacted(self):
+        self.assertEqual(
+            redact_json({"detail": "failed for url ?token=s3cr3t&x=1"}),
+            {"detail": "failed for url ?token=***&x=1"},
+        )
+
+    def test_structure_and_non_string_leaves_survive(self):
+        payload = {"records_sent": 12, "ok": True, "missing": None, "ids": [1, 2]}
+        self.assertEqual(redact_json(payload), payload)
+
+    def test_a_bare_string_is_redacted(self):
+        self.assertEqual(redact_json("?token=abc"), "?token=***")

--- a/adl/src/adl/core/tests/test_redaction_write_points.py
+++ b/adl/src/adl/core/tests/test_redaction_write_points.py
@@ -1,0 +1,163 @@
+"""
+Seam tests: every write point that stores an exception's text redacts it.
+
+The unit tests in ``test_redaction`` prove the redactor; these prove it is
+actually reached on each path that persists or serves failure text — the
+regression that matters, because the leak was never in the redactor but in
+a write that forgot to call one.
+"""
+
+from datetime import datetime, timezone as py_tz
+from unittest.mock import patch
+
+from django.test import SimpleTestCase, TestCase
+
+from adl.core.dispatch_checks import (
+    normalise_dispatch_test_result,
+    run_dispatch_connection_test,
+)
+from adl.core.models import Wis2BoxUpload
+from adl.core.source_checks import (
+    SourceCheckResult,
+    SourceCheckStatus,
+    normalise_source_check_result,
+)
+from adl.core.logging import TaskLogger
+from adl.core.tasks import dispatch_station
+from adl.monitoring.models import StationLinkActivityLog
+from .factories import StationLinkFactory, Wis2BoxUploadFactory
+from .helpers import make_test_plugin
+
+LEAKY_ERROR = (
+    "401 Client Error: Unauthorized for url: "
+    "https://api.example.org/data?token=s3cr3t-value&station=42"
+)
+
+
+class PullWritePointTests(TestCase):
+    """process_station's FAILED log carries no credential."""
+
+    def setUp(self):
+        self.plugin = make_test_plugin()
+        self.link = StationLinkFactory()
+
+        window = (
+            datetime(2025, 1, 1, 0, 0, tzinfo=py_tz.utc),
+            datetime(2025, 1, 2, 0, 0, tzinfo=py_tz.utc),
+        )
+        patcher = patch.object(
+            type(self.plugin), "get_dates_for_station", return_value=window
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_query_string_token_is_redacted_in_the_stored_message(self):
+        with patch.object(
+            self.plugin, "get_station_data", side_effect=RuntimeError(LEAKY_ERROR)
+        ):
+            self.plugin.process_station(self.link, bypass_lock=True)
+
+        log = StationLinkActivityLog.objects.get()
+        self.assertNotIn("s3cr3t-value", log.message)
+        self.assertIn("token=***", log.message)
+        # The diagnostic part of the message survives.
+        self.assertIn("401 Client Error", log.message)
+        self.assertIn("station=42", log.message)
+
+
+class PushWritePointTests(TestCase):
+    """dispatch_station's FAILED log carries no credential."""
+
+    def setUp(self):
+        self.link = StationLinkFactory()
+        self.channel = Wis2BoxUploadFactory()
+        self.channel.network_connections.add(self.link.network_connection)
+
+    def test_credential_is_redacted_in_the_stored_message(self):
+        error = RuntimeError("upload rejected (password=hunter2)")
+        with patch(
+            "adl.core.tasks.get_station_dispatch_records",
+            return_value=[{"station_id": self.link.station_id}],
+        ), patch.object(Wis2BoxUpload, "send_station_data", side_effect=error):
+            with self.assertRaises(RuntimeError):
+                dispatch_station(self.channel.id, self.link.id)
+
+        log = StationLinkActivityLog.objects.get()
+        self.assertNotIn("hunter2", log.message)
+        self.assertIn("password=***", log.message)
+
+
+class SourceCheckWritePointTests(SimpleTestCase):
+    """A plugin's own source-check message is redacted before it is stored."""
+
+    def test_plugin_message_is_redacted(self):
+        result = normalise_source_check_result(
+            SourceCheckResult(status=SourceCheckStatus.FAILED, message=LEAKY_ERROR)
+        )
+
+        self.assertNotIn("s3cr3t-value", result.message)
+        self.assertIn("token=***", result.message)
+
+    def test_status_and_category_still_survive_normalisation(self):
+        result = normalise_source_check_result(
+            SourceCheckResult(
+                status=SourceCheckStatus.FAILED,
+                category="AUTH_FAILED",
+                message="no secret here",
+            )
+        )
+
+        self.assertEqual(result.status, SourceCheckStatus.FAILED)
+        self.assertEqual(result.category, "AUTH_FAILED")
+        self.assertEqual(result.message, "no secret here")
+
+    def test_unknown_category_is_still_dropped(self):
+        result = normalise_source_check_result(
+            SourceCheckResult(status=SourceCheckStatus.FAILED, category="MADE_UP")
+        )
+
+        self.assertIsNone(result.category)
+
+
+class DispatchTestConnectionWritePointTests(SimpleTestCase):
+    """A channel's test-connection message is redacted for the operator."""
+
+    def test_channel_supplied_message_is_redacted(self):
+        result = normalise_dispatch_test_result(
+            {"ok": False, "supported": True, "message": LEAKY_ERROR, "latency_ms": 5}
+        )
+
+        self.assertNotIn("s3cr3t-value", result["message"])
+        self.assertIn("token=***", result["message"])
+
+    def test_raised_exception_text_is_redacted(self):
+        class Channel:
+            id = 1
+
+            def test_connection(self):
+                raise RuntimeError(LEAKY_ERROR)
+
+        result = run_dispatch_connection_test(Channel())
+
+        self.assertFalse(result["ok"])
+        self.assertNotIn("s3cr3t-value", result["message"])
+        self.assertIn("token=***", result["message"])
+
+
+class StreamedLogTests(SimpleTestCase):
+    """What leaves the process for a browser carries no credential."""
+
+    def test_sse_message_is_redacted_but_the_local_log_is_not(self):
+        logger = TaskLogger(task_id="abc", plugin_label="Test")
+
+        with patch("adl.core.logging.send_event") as send_event, \
+                patch.object(logger, "standard_logger") as standard_logger:
+            logger.error("fetch failed: %s", LEAKY_ERROR)
+
+        streamed = send_event.call_args.args[2]["message"]
+        self.assertNotIn("s3cr3t-value", streamed)
+        self.assertIn("token=***", streamed)
+
+        # The worker's own log keeps the full text — it is not a shared surface.
+        logged = standard_logger.error.call_args.args[0]
+        self.assertIn("s3cr3t-value", logged)

--- a/adl/src/adl/monitoring/migrations/0010_redact_stored_secrets.py
+++ b/adl/src/adl/monitoring/migrations/0010_redact_stored_secrets.py
@@ -1,0 +1,95 @@
+"""
+Redact credentials already stored in operator-visible failure text.
+
+The forward fix (``adl.core.redaction``) only covers rows written from now
+on. Rows written before it — a 401 from a source that authenticates with a
+query parameter, say — still carry the token in ``message``, and the
+monitoring API still serves it. This sweeps them.
+
+Irreversible on purpose: the reverse is a no-op because the secret is gone,
+which is the whole point. Only rows the redactor actually changes are
+written back, so an install with no leaked rows pays one scan and no
+updates.
+
+Runs outside a transaction and writes one row at a time. The activity log
+is a TimescaleDB hypertable: an update that names only the primary key
+cannot exclude a chunk, so each write carries the row's ``time`` as well and
+touches one chunk instead of all of them. Installs that have enabled
+compression on old chunks must decompress them before migrating — Timescale
+refuses updates to a compressed chunk, and that is a deployment decision,
+not something a migration should make silently.
+"""
+
+from django.db import migrations
+
+from adl.core.redaction import SCHEME_NAMES, SENSITIVE_SUFFIXES
+
+BATCH_SIZE = 1000
+
+# Cheap SQL pre-filter: any row whose text mentions a credential-ish word at
+# all. Built from the redactor's own vocabulary — retyping the word list here
+# is how the backfill would come to miss what the forward fix catches. The
+# redactor still decides whether anything is really there; this only keeps
+# the sweep from loading every log row ever written.
+#
+# ``tokens?`` is the redactor's spelling of an optional plural, which POSIX
+# does not read the same way. The optional character is dropped and a
+# trailing ``[a-z]*`` put back instead, so the pre-filter still catches
+# ``tokens=`` — and over-matches, which costs a pre-filter nothing.
+_WORDS = "|".join(
+    suffix[:-2] if suffix.endswith("?") else suffix for suffix in SENSITIVE_SUFFIXES
+)
+_SCHEMES = "|".join(SCHEME_NAMES)
+
+CANDIDATE_REGEX = (
+    rf"({_WORDS})[a-z]*[[:space:]]*[\"']?[[:space:]]*[:=]"
+    r"|://[^/@[:space:]]+:[^/@[:space:]]*@"
+    rf"|({_SCHEMES})[[:space:]]"
+)
+
+
+def _redact_model(model, field, redact, keys):
+    candidates = (
+        model.objects.filter(**{f"{field}__iregex": CANDIDATE_REGEX})
+        .only(*keys, field)
+        .order_by("pk")
+    )
+
+    for row in candidates.iterator(chunk_size=BATCH_SIZE):
+        original = getattr(row, field)
+        redacted = redact(original)
+        if redacted == original:
+            continue
+        lookup = {key: getattr(row, key) for key in keys}
+        model.objects.filter(**lookup).update(**{field: redacted})
+
+
+def redact_stored_secrets(apps, schema_editor):
+    from adl.core.redaction import redact_secrets
+
+    # The activity log is partitioned on ``time``; carrying it in the lookup
+    # is what lets Timescale touch a single chunk per write.
+    sweeps = (
+        ("StationLinkActivityLog", "message", ("pk", "time")),
+        ("SourceProbeResult", "message", ("pk",)),
+        ("NetworkConnectionHealth", "headline_message", ("pk",)),
+    )
+
+    for model_name, field, keys in sweeps:
+        _redact_model(
+            apps.get_model("monitoring", model_name), field, redact_secrets, keys
+        )
+
+
+class Migration(migrations.Migration):
+    # A data sweep over the whole activity-log history has no business
+    # holding one transaction open across every chunk it rewrites.
+    atomic = False
+
+    dependencies = [
+        ("monitoring", "0009_sourceproberesult"),
+    ]
+
+    operations = [
+        migrations.RunPython(redact_stored_secrets, migrations.RunPython.noop),
+    ]

--- a/adl/src/adl/monitoring/serializers.py
+++ b/adl/src/adl/monitoring/serializers.py
@@ -4,23 +4,40 @@ from datetime import timedelta
 from django_celery_results.models import TaskResult
 from rest_framework import serializers
 
+from adl.core.redaction import redact_json, redact_secrets
+
 from .models import StationLinkActivityLog
 
 
 class TaskResultSerializer(serializers.ModelSerializer):
+    """
+    A Celery task result, redacted at the boundary.
+
+    Everywhere else ADL redacts at the write point, but these two fields are
+    written by ``django_celery_results`` from the re-raised exception — core
+    never touches the row and cannot redact it on the way in. So this is the
+    one place redaction happens on read, and it has to stay here as long as
+    a failing task re-raises after logging.
+    """
+
     result = serializers.SerializerMethodField()
-    
+    traceback = serializers.SerializerMethodField()
+
     class Meta:
         model = TaskResult
         fields = ("date_created", "date_done", "status", "result", "traceback",)
-    
+
     def get_result(self, obj):
         try:
             result = json.loads(obj.result)
-        except json.JSONDecodeError:
-            result = obj.result
-        
-        return result
+        except (TypeError, json.JSONDecodeError):
+            # TypeError: a task that recorded no result at all stores NULL.
+            return redact_secrets(obj.result)
+
+        return redact_json(result)
+
+    def get_traceback(self, obj):
+        return redact_secrets(obj.traceback)
 
 
 class StationLinkActivityLogSerializer(serializers.ModelSerializer):

--- a/adl/src/adl/monitoring/tests/test_secret_backfill.py
+++ b/adl/src/adl/monitoring/tests/test_secret_backfill.py
@@ -1,0 +1,132 @@
+"""
+The backfill migration must actually clear secrets from rows already stored.
+
+Exercised against the live app registry rather than through the migration
+executor: what is being proven is the sweep — its candidate filter runs as
+real SQL, and rows with nothing to redact are left untouched.
+"""
+
+from importlib import import_module
+
+from django.apps import apps
+from django.test import TestCase
+from django.utils import timezone as dj_timezone
+
+from adl.core.tests.factories import StationLinkFactory
+from adl.monitoring.models import SourceProbeResult, StationLinkActivityLog
+
+migration = import_module("adl.monitoring.migrations.0010_redact_stored_secrets")
+
+LEAKY = ("401 Client Error: Unauthorized for url: "
+         "https://api.example.org/data?token=s3cr3t-value&station=42")
+CLEAN = "Processed 12 records."
+
+
+class SecretBackfillTests(TestCase):
+    def setUp(self):
+        self.link = StationLinkFactory()
+        self.connection = self.link.network_connection
+
+    def make_log(self, message):
+        return StationLinkActivityLog.objects.create(
+            time=dj_timezone.now(),
+            station_link=self.link,
+            direction="pull",
+            message=message,
+        )
+
+    def test_leaked_activity_log_message_is_redacted(self):
+        log = self.make_log(LEAKY)
+
+        migration.redact_stored_secrets(apps, None)
+
+        log.refresh_from_db()
+        self.assertNotIn("s3cr3t-value", log.message)
+        self.assertIn("token=***", log.message)
+
+    def test_clean_rows_are_left_exactly_as_they_were(self):
+        log = self.make_log(CLEAN)
+
+        migration.redact_stored_secrets(apps, None)
+
+        log.refresh_from_db()
+        self.assertEqual(log.message, CLEAN)
+
+    def test_null_message_survives_the_sweep(self):
+        log = self.make_log(None)
+
+        migration.redact_stored_secrets(apps, None)
+
+        log.refresh_from_db()
+        self.assertIsNone(log.message)
+
+    def test_probe_results_are_swept_too(self):
+        probe = SourceProbeResult.objects.create(
+            connection=self.connection,
+            check_id="source_check",
+            layer="source",
+            status="FAILED",
+            message=LEAKY,
+            at=dj_timezone.now(),
+        )
+
+        migration.redact_stored_secrets(apps, None)
+
+        probe.refresh_from_db()
+        self.assertNotIn("s3cr3t-value", probe.message)
+
+    def test_running_the_sweep_twice_is_a_no_op_the_second_time(self):
+        log = self.make_log(LEAKY)
+
+        migration.redact_stored_secrets(apps, None)
+        log.refresh_from_db()
+        once = log.message
+
+        migration.redact_stored_secrets(apps, None)
+        log.refresh_from_db()
+        self.assertEqual(log.message, once)
+
+
+class CandidateFilterTests(TestCase):
+    """
+    The SQL pre-filter must not be narrower than the redactor.
+
+    Anything the redactor would change has to survive the filter, or the
+    backfill silently skips rows the forward fix would have caught — the
+    drift that a hand-retyped word list invites.
+    """
+
+    def setUp(self):
+        self.link = StationLinkFactory()
+
+    def assert_swept(self, message):
+        log = StationLinkActivityLog.objects.create(
+            time=dj_timezone.now(),
+            station_link=self.link,
+            direction="pull",
+            message=message,
+        )
+
+        migration.redact_stored_secrets(apps, None)
+
+        log.refresh_from_db()
+        self.assertNotEqual(log.message, message, f"not swept: {message!r}")
+
+    def test_every_leak_shape_the_redactor_handles_is_a_candidate(self):
+        shapes = [
+            "?token=abc123",
+            "?tokens=abc123",
+            "?api_key=abc123",
+            "?API_KEY=abc123",
+            "?client_secret=abc123",
+            "?credentials=abc123",
+            'password: "hunter2"',
+            "Authorization: Bearer abcdef123456",
+            "sent Token abcdef123456 upstream",
+            "sent Digest abcdef123456 upstream",
+            "ftp://alice:hunter2@ftp.example.org/in/",
+        ]
+
+        for shape in shapes:
+            with self.subTest(shape=shape):
+                self.assert_swept(shape)

--- a/adl/src/adl/monitoring/tests/test_task_result_redaction.py
+++ b/adl/src/adl/monitoring/tests/test_task_result_redaction.py
@@ -1,0 +1,51 @@
+"""
+The Celery task-result surface is redacted on read.
+
+``django_celery_results`` writes the exception text and traceback of a
+re-raised task itself, so core has no write point on that row — the
+monitoring API is where it has to be caught.
+"""
+
+import json
+
+from django.test import SimpleTestCase
+from django_celery_results.models import TaskResult
+
+from adl.monitoring.serializers import TaskResultSerializer
+
+LEAKY_URL = "https://api.example.org/data?token=s3cr3t-value&station=42"
+
+
+def serialize(**kwargs):
+    return TaskResultSerializer(TaskResult(**kwargs)).data
+
+
+class TaskResultRedactionTests(SimpleTestCase):
+    def test_traceback_is_redacted(self):
+        data = serialize(
+            traceback=f"Traceback (most recent call last):\n  HTTPError: 401 for url: {LEAKY_URL}"
+        )
+
+        self.assertNotIn("s3cr3t-value", data["traceback"])
+        self.assertIn("token=***", data["traceback"])
+        self.assertIn("Traceback", data["traceback"])
+
+    def test_json_result_is_redacted_and_keeps_its_shape(self):
+        data = serialize(
+            result=json.dumps({"exc_message": [f"401 for url: {LEAKY_URL}"], "records": 0})
+        )
+
+        self.assertNotIn("s3cr3t-value", json.dumps(data["result"]))
+        self.assertEqual(data["result"]["records"], 0)
+
+    def test_non_json_result_is_still_redacted(self):
+        data = serialize(result=f"401 Client Error for url: {LEAKY_URL}")
+
+        self.assertNotIn("s3cr3t-value", data["result"])
+        self.assertIn("token=***", data["result"])
+
+    def test_absent_result_and_traceback_do_not_break_serialisation(self):
+        data = serialize()
+
+        self.assertIsNone(data["result"])
+        self.assertIsNone(data["traceback"])


### PR DESCRIPTION
Closes #168.

A source that authenticates with a query parameter leaked its token into `StationLinkActivityLog.message`: `requests` puts the full request URL in its `HTTPError` text, core stored `str(e)` verbatim, and the monitoring API served it back.

## The four decisions the issue left open

| Decision | Choice |
|---|---|
| **Where redaction happens** | At the **write point**. The row is not the only surface — the admin renders it, exports carry it, workers echo it — so redacting once where the text is produced bounds the exposure instead of asking every new reader to remember. |
| **What patterns** | Named secrets only: a key whose name *ends* in a sensitive word (`api_key`, `client_secret`, `ACCESS_TOKEN`), an HTTP authorization scheme (`Bearer`/`Basic`/`Token`/`Digest`), and URL userinfo. The key is kept (`token=***`) so the message still says which credential was involved. |
| **Existing rows** | Redacted by data migration `monitoring/0010`, irreversible by design. |
| **Plugins putting credentials in query strings** | Out of scope — it lives in sibling repos. Core instead redacts plugin-supplied text on the way in, so no plugin has to be trusted to do it. |

## What changed

- **`adl/core/redaction.py`** — `redact_secrets()` for text, `redact_json()` for parsed structures.
- **`classification.mark_failed()`** — the whole terminal-failure gesture (status, success flag, redacted message, classification stamps) in one call, replacing the block duplicated across `registries.py`, `tasks.py` and `dispatchers/__init__.py`. That duplication was the real defect class: every copy was somewhere a later one could forget to redact.
- **Plugin-supplied text** is redacted by core on the way in — `SourceCheckResult.message` and a channel's `test_connection()` message.
- **Two surfaces beyond the ones the issue named**, found during review: `TaskLogger` redacts what it pushes to the SSE stream, and `TaskResultSerializer` redacts on **read** — `django_celery_results` writes a re-raised task's text and traceback itself, so core has no write point on that row. It is the one documented exception to the write-point rule.
- **`monitoring/0010`** sweeps rows already written. Runs outside a transaction and carries `time` in each write so the activity-log hypertable can exclude chunks; its SQL pre-filter is derived from the redactor's own vocabulary rather than retyped.

## Deliberately not done

- **Worker-log tracebacks (`exc_info`) are not stripped.** A host-local log is not a shared surface, and the traceback is why the entry exists. Noted in code and in the architecture doc so it does not read as an oversight.
- **The redactor over-matches on suffix** — `sort_key=asc` is masked too. Losing a sort order from an error message costs less than keeping a token in one; documented as the intended bias.

## Verification

- 490 tests pass, 36 of them new (redactor unit tests, write-point seam tests, backfill tests, task-result serializer tests).
- Migration applies and reverses cleanly on the dev database.

⚠️ **Deployment note:** installs with TimescaleDB compression enabled on old activity-log chunks must decompress before migrating — Timescale refuses updates to a compressed chunk. That is a deployment decision, not something a migration should make silently; it is stated in the migration docstring.