### PR TITLE
fix: gate the manual-action admin views on a change permission

### DIFF
--- a/adl/src/adl/core/components.py
+++ b/adl/src/adl/core/components.py
@@ -3,6 +3,7 @@ from django.urls import reverse
 from django.utils import timezone as dj_timezone
 from wagtail.admin.ui.components import Component
 
+from adl.core.permissions import can_manage_channel, can_manage_connection
 from adl.core.source_checks import CHECK_STATION_SOURCE
 from adl.monitoring.health import configuration_drift, probe_age_minutes
 from adl.monitoring.models import SourceProbeResult, StationLinkActivityLog
@@ -14,7 +15,9 @@ class StationLinkCollectionStatusPanel(Component):
     def get_context_data(self, parent_context):
         context = super().get_context_data(parent_context)
         station_link = parent_context.get('station_link')
-        
+        request = parent_context.get('request')
+        user = getattr(request, 'user', None)
+
         # get latest log entry for this station link
         latest_pull_log = StationLinkActivityLog.objects.filter(
             station_link=station_link, direction="pull"
@@ -30,15 +33,23 @@ class StationLinkCollectionStatusPanel(Component):
                     dispatch_channel=dispatch_channel
                 ).order_by('-time').first()
                 dispatch_channel.latest_push_log = latest_push_log
-        
+                # Per channel, not once for the panel: a user may hold the
+                # change permission on one channel type and not another
+                dispatch_channel.can_trigger_dispatch = can_manage_channel(
+                    user, dispatch_channel)
+
         station_link.latest_pull_log = latest_pull_log
         station_link.dispatch_channels = dispatch_channels
         context['station_link'] = station_link
-        
-        if 'request' in parent_context:
-            context['request'] = parent_context['request']
-            context['csrf_token'] = get_token(parent_context['request'])
-        
+
+        # Hidden, not disabled, for a user who cannot take the action
+        context['can_trigger_collection'] = can_manage_connection(
+            user, station_link.network_connection)
+
+        if request is not None:
+            context['request'] = request
+            context['csrf_token'] = get_token(request)
+
         return context
 
 
@@ -57,10 +68,6 @@ class StationLinkSourceCheckPanel(Component):
     template_name = 'core/panels/sl_source_check.html'
 
     def get_context_data(self, parent_context):
-        # Imported here, not at module level: the views module imports core
-        # models and utils, which import back into this app at startup
-        from adl.monitoring.views.health import PROBE_PERMISSION
-
         context = super().get_context_data(parent_context)
         station_link = parent_context.get('station_link')
         request = parent_context.get('request')
@@ -82,8 +89,8 @@ class StationLinkSourceCheckPanel(Component):
         context['latest_result'] = latest
         context['configuration_drift'] = drift if drift.drifted else None
         context['show_check_button'] = (
-            request is not None
-            and request.user.has_perm(PROBE_PERMISSION)
+            can_manage_connection(getattr(request, 'user', None),
+                                  station_link.network_connection)
             and station_link.station_source_check_supported
         )
         context['check_source_url'] = reverse('station_link_check_source',

--- a/adl/src/adl/core/permissions.py
+++ b/adl/src/adl/core/permissions.py
@@ -1,0 +1,70 @@
+"""
+Who may take a manual action on a connection or a dispatch channel.
+
+The manual-action buttons — trigger a collection, dispatch now, reset the
+dispatch locks, test a destination, probe a source — are registered through
+``register_admin_urls``, which Wagtail wraps in ``require_admin_access``.
+That gate is "any user who can log into the admin", including one
+provisioned purely to read the monitoring pages, so each action needs a
+gate of its own.
+
+The gate is the **change permission for the object being acted on**, not a
+dedicated permission per action: someone who can edit a connection or a
+channel and its credentials can already make the runtime dial that host,
+and a new permission would have to be discovered and assigned across 26
+deployments before the buttons worked again.
+
+Both models are polymorphic, and the admin registers a viewset per
+*concrete subclass* — so ``change_ftpconnection`` is what a deployment
+actually grants a connection operator, while ``change_networkconnection``
+is what a superuser or a deliberately-global group holds. Either one is
+"may edit this object", so both pass. Reading only the base would leave the
+buttons visible to nobody but a superuser, which is the outcome the
+"no new permission to assign" reasoning exists to avoid.
+
+One rule, one module: the ingestion diagnostic's probe and run buttons ask
+the same question about the same connection as the station-link page's
+collection trigger, and two spellings of it would answer differently for an
+operator granted rights on a concrete connection type — the same user, the
+same object, two verdicts.
+"""
+
+
+def _change_perm(opts):
+    return f"{opts.app_label}.change_{opts.model_name}"
+
+
+def _can_change(user, instance, base_model):
+    """Whether ``user`` holds the change permission for ``instance``'s own
+    concrete class or for its polymorphic base ``base_model``.
+
+    ``user`` may be ``None``: a component renders without a request in
+    contexts that have no user to ask about, and the answer there is "no
+    button", not an error.
+    """
+    if user is None:
+        return False
+
+    return (user.has_perm(_change_perm(instance._meta))
+            or user.has_perm(_change_perm(base_model._meta)))
+
+
+def can_manage_connection(user, connection):
+    """Whether ``user`` may take a manual action against ``connection`` —
+    run it, probe its source, or trigger a collection for one of its
+    station links.
+
+    A station link is gated on its connection rather than on itself: the
+    connection is what holds the credentials the action will use.
+    """
+    from .models import NetworkConnection
+
+    return _can_change(user, connection, NetworkConnection)
+
+
+def can_manage_channel(user, channel):
+    """Whether ``user`` may take a manual action against ``channel`` —
+    dispatch it, reset its locks, or test its destination."""
+    from .models import DispatchChannel
+
+    return _can_change(user, channel, DispatchChannel)

--- a/adl/src/adl/core/templates/core/dispatch_channel_locks.html
+++ b/adl/src/adl/core/templates/core/dispatch_channel_locks.html
@@ -72,21 +72,23 @@
             </p>
         {% endif %}
 
-        <div style="display:flex; gap:10px; margin:20px 0;">
-            <form method="post" action="{% url 'dispatch_channel_reset' channel.id %}">
-                {% csrf_token %}
-                <input type="hidden" name="scope" value="stale">
-                <button type="submit" class="button"
-                        {% if not worker_responsive or stale_count == 0 %}disabled{% endif %}>
-                    {% blocktrans count counter=stale_count %}Clear {{ counter }} stale lock &amp; dispatch{% plural %}Clear {{ counter }} stale locks &amp; dispatch{% endblocktrans %}
-                </button>
-            </form>
-            <form method="post" action="{% url 'dispatch_channel_reset' channel.id %}"
-                  onsubmit="return confirm('{% trans 'Clear ALL locks, including RUNNING ones? A running dispatch keeps executing and a duplicate may start for the same station, which can send the same records twice.' %}')">
-                {% csrf_token %}
-                <input type="hidden" name="scope" value="all">
-                <button type="submit" class="button no">{% trans "Clear ALL locks & dispatch" %}</button>
-            </form>
-        </div>
+        {% if can_manage_channel %}
+            <div style="display:flex; gap:10px; margin:20px 0;">
+                <form method="post" action="{% url 'dispatch_channel_reset' channel.id %}">
+                    {% csrf_token %}
+                    <input type="hidden" name="scope" value="stale">
+                    <button type="submit" class="button"
+                            {% if not worker_responsive or stale_count == 0 %}disabled{% endif %}>
+                        {% blocktrans count counter=stale_count %}Clear {{ counter }} stale lock &amp; dispatch{% plural %}Clear {{ counter }} stale locks &amp; dispatch{% endblocktrans %}
+                    </button>
+                </form>
+                <form method="post" action="{% url 'dispatch_channel_reset' channel.id %}"
+                      onsubmit="return confirm('{% trans 'Clear ALL locks, including RUNNING ones? A running dispatch keeps executing and a duplicate may start for the same station, which can send the same records twice.' %}')">
+                    {% csrf_token %}
+                    <input type="hidden" name="scope" value="all">
+                    <button type="submit" class="button no">{% trans "Clear ALL locks & dispatch" %}</button>
+                </form>
+            </div>
+        {% endif %}
     </div>
 {% endblock %}

--- a/adl/src/adl/core/templates/core/dispatch_channel_station_links.html
+++ b/adl/src/adl/core/templates/core/dispatch_channel_station_links.html
@@ -30,14 +30,16 @@
         </div>
 
         <div style="display:flex; gap:10px; margin:15px 0;">
-            <form method="post" action="{% url 'dispatch_channel_dispatch_now' channel.id %}">
-                {% csrf_token %}
-                <button type="submit" class="button">{% trans "Dispatch now" %}</button>
-            </form>
-            <form method="post" action="{% url 'dispatch_channel_test_connection' channel.id %}">
-                {% csrf_token %}
-                <button type="submit" class="button button-secondary">{% trans "Test connection" %}</button>
-            </form>
+            {% if can_manage_channel %}
+                <form method="post" action="{% url 'dispatch_channel_dispatch_now' channel.id %}">
+                    {% csrf_token %}
+                    <button type="submit" class="button">{% trans "Dispatch now" %}</button>
+                </form>
+                <form method="post" action="{% url 'dispatch_channel_test_connection' channel.id %}">
+                    {% csrf_token %}
+                    <button type="submit" class="button button-secondary">{% trans "Test connection" %}</button>
+                </form>
+            {% endif %}
             <a href="{% url 'dispatch_channel_locks' channel.id %}" class="button button-secondary">
                 {% trans "Show active locks" %}
             </a>

--- a/adl/src/adl/core/templates/core/panels/sl_collection_status.html
+++ b/adl/src/adl/core/templates/core/panels/sl_collection_status.html
@@ -95,6 +95,7 @@
             </div>
         {% endif %}
 
+        {% if can_trigger_collection %}
         <div class="manual-trigger">
             <form method="post" action="{% url 'trigger_station_collection' station_link.id %}"
                   class="manual-trigger__form">
@@ -109,6 +110,7 @@
                 <span class="manual-trigger__help">{% trans "Manually fetch latest data from source" %}</span>
             </form>
         </div>
+        {% endif %}
     </div>
 
     {# Push Status Section #}
@@ -201,6 +203,7 @@
                         {% endif %}
 
                         {# Manual Dispatch Trigger Form #}
+                        {% if channel.can_trigger_dispatch %}
                         <div class="manual-trigger manual-trigger--compact">
                             <form method="post" action="{% url 'trigger_station_dispatch' station_link.id channel.id %}"
                                   class="manual-trigger__form">
@@ -217,6 +220,7 @@
                                 <span class="manual-trigger__help">{% trans "Manually send data to this channel" %}</span>
                             </form>
                         </div>
+                        {% endif %}
                     </div>
                 {% endfor %}
             </div>

--- a/adl/src/adl/core/tests/test_manual_action_permissions.py
+++ b/adl/src/adl/core/tests/test_manual_action_permissions.py
@@ -1,0 +1,307 @@
+"""
+Seam tests for the gate on the five manual-action admin views.
+
+Permission is an HTTP-level property here — whether the task was enqueued,
+the locks cleared or the destination dialled is only observable at the
+view — so these drive the views through the test client and assert on the
+side effect, never on the helper alone.
+
+Each action is exercised three ways: refused for an admin-access user with
+no change rights, allowed for one granted the *concrete* subclass's change
+permission (what a deployment actually assigns), and allowed for one
+granted only the polymorphic base's.
+"""
+
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
+from django.core.cache import cache
+from django.test import RequestFactory, TestCase
+from django.urls import reverse
+
+from adl.core.tasks import dispatch_station_lock_key
+from .factories import StationLinkFactory, Wis2BoxUploadFactory
+
+
+def make_user(username, *codenames):
+    """An admin-access user holding exactly ``codenames`` and nothing else."""
+    user = get_user_model().objects.create_user(
+        username=username, email=f"{username}@example.com", password="test-pass"
+    )
+    user.user_permissions.add(
+        Permission.objects.get(codename="access_admin"),
+        *[Permission.objects.get(codename=c) for c in codenames],
+    )
+    return user
+
+
+class ManualActionTestCase(TestCase):
+    def setUp(self):
+        cache.clear()
+        self.addCleanup(cache.clear)
+        self.link = StationLinkFactory()
+        self.connection = self.link.network_connection
+        self.channel = Wis2BoxUploadFactory()
+        self.channel.network_connections.add(self.connection)
+
+    def login(self, *codenames):
+        self.client.force_login(make_user("operator", *codenames))
+
+    def assertRefused(self, url, **post_kwargs):
+        """The view refused: Wagtail's admin wrapper turns the raised
+        PermissionDenied into a redirect home, and the raw 403 surfaces on
+        XHR."""
+        response = self.client.post(url, follow=True, **post_kwargs)
+        self.assertContains(response, "do not have permission")
+
+        xhr = self.client.post(url, HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+                               **post_kwargs)
+        self.assertEqual(xhr.status_code, 403)
+
+
+class TriggerStationCollectionPermissionTests(ManualActionTestCase):
+    """The one ingestion-side action: gated on its *connection*, which is
+    what holds the credentials the run will use."""
+
+    def setUp(self):
+        super().setUp()
+        self.url = reverse("trigger_station_collection", args=[self.link.id])
+
+    def test_admin_access_alone_never_enqueues_a_run(self):
+        self.login()
+
+        with patch("adl.core.views.process_station_link_batch") as task:
+            self.assertRefused(self.url)
+
+        task.delay.assert_not_called()
+
+    def test_connection_change_permission_enqueues_the_run(self):
+        self.login("change_networkconnection")
+
+        with patch("adl.core.views.process_station_link_batch") as task:
+            response = self.client.post(self.url)
+
+        task.delay.assert_called_once_with(self.connection.id, [self.link.id])
+        self.assertEqual(response.status_code, 302)
+
+    def test_dispatch_permission_does_not_unlock_the_ingestion_action(self):
+        self.login("change_dispatchchannel")
+
+        with patch("adl.core.views.process_station_link_batch") as task:
+            self.assertRefused(self.url)
+
+        task.delay.assert_not_called()
+
+    def panel_context(self, user):
+        from adl.core.components import StationLinkCollectionStatusPanel
+
+        request = RequestFactory().get("/admin/")
+        request.user = user
+        return StationLinkCollectionStatusPanel().get_context_data(
+            {"station_link": self.link, "request": request}
+        )
+
+    def test_button_is_hidden_for_unpermitted_users(self):
+        context = self.panel_context(make_user("operator"))
+
+        self.assertFalse(context["can_trigger_collection"])
+
+    def test_button_is_shown_with_the_connection_change_permission(self):
+        context = self.panel_context(
+            make_user("permitted", "change_networkconnection"))
+
+        self.assertTrue(context["can_trigger_collection"])
+
+    def test_per_channel_dispatch_button_follows_that_channel(self):
+        # Answered per channel, not once for the panel: a user may hold the
+        # change permission on one channel type and not another
+        context = self.panel_context(make_user("permitted", "change_wis2boxupload"))
+        channels = {c.id: c for c in context["station_link"].dispatch_channels}
+
+        self.assertTrue(channels[self.channel.id].can_trigger_dispatch)
+
+    def test_per_channel_dispatch_button_is_hidden_without_the_permission(self):
+        context = self.panel_context(
+            make_user("permitted", "change_networkconnection"))
+        channels = {c.id: c for c in context["station_link"].dispatch_channels}
+
+        self.assertFalse(channels[self.channel.id].can_trigger_dispatch)
+
+
+class ChannelActionPermissionTests(ManualActionTestCase):
+    """The four dispatch-side actions. Each accepts the concrete channel
+    type's change permission as well as the polymorphic base's."""
+
+    def channel_url(self, name):
+        return reverse(name, args=[self.channel.id])
+
+    def test_dispatch_now_refuses_without_change_rights(self):
+        self.login()
+
+        with patch("adl.core.views.perform_channel_dispatch") as task:
+            self.assertRefused(self.channel_url("dispatch_channel_dispatch_now"))
+
+        task.delay.assert_not_called()
+
+    def test_dispatch_now_accepts_the_concrete_channel_permission(self):
+        self.login("change_wis2boxupload")
+
+        with patch("adl.core.views.perform_channel_dispatch") as task:
+            response = self.client.post(
+                self.channel_url("dispatch_channel_dispatch_now"))
+
+        task.delay.assert_called_once_with(self.channel.id)
+        self.assertEqual(response.status_code, 302)
+
+    def test_dispatch_now_accepts_the_base_channel_permission(self):
+        self.login("change_dispatchchannel")
+
+        with patch("adl.core.views.perform_channel_dispatch") as task:
+            self.client.post(self.channel_url("dispatch_channel_dispatch_now"))
+
+        task.delay.assert_called_once_with(self.channel.id)
+
+    def test_reset_refuses_without_change_rights_and_leaves_locks_held(self):
+        lock = dispatch_station_lock_key(self.channel.id, self.link.id)
+        cache.set(lock, "locked", timeout=300)
+        self.login()
+
+        with patch("adl.core.views.perform_channel_dispatch") as task:
+            self.assertRefused(self.channel_url("dispatch_channel_reset"))
+
+        self.assertEqual(cache.get(lock), "locked")
+        task.delay.assert_not_called()
+
+    def test_reset_clears_locks_with_the_concrete_channel_permission(self):
+        lock = dispatch_station_lock_key(self.channel.id, self.link.id)
+        cache.set(lock, "locked", timeout=300)
+        self.login("change_wis2boxupload")
+
+        with patch("adl.core.views.perform_channel_dispatch"):
+            self.client.post(self.channel_url("dispatch_channel_reset"))
+
+        self.assertIsNone(cache.get(lock))
+
+    def test_reset_clears_locks_with_the_base_channel_permission(self):
+        lock = dispatch_station_lock_key(self.channel.id, self.link.id)
+        cache.set(lock, "locked", timeout=300)
+        self.login("change_dispatchchannel")
+
+        with patch("adl.core.views.perform_channel_dispatch"):
+            self.client.post(self.channel_url("dispatch_channel_reset"))
+
+        self.assertIsNone(cache.get(lock))
+
+    def test_station_dispatch_refuses_without_change_rights(self):
+        url = reverse("trigger_station_dispatch",
+                      args=[self.link.id, self.channel.id])
+        self.login()
+
+        with patch("adl.core.views.perform_channel_dispatch") as task:
+            self.assertRefused(url)
+
+        task.delay.assert_not_called()
+
+    def test_station_dispatch_accepts_the_concrete_channel_permission(self):
+        url = reverse("trigger_station_dispatch",
+                      args=[self.link.id, self.channel.id])
+        self.login("change_wis2boxupload")
+
+        with patch("adl.core.views.perform_channel_dispatch") as task:
+            self.client.post(url)
+
+        task.delay.assert_called_once_with(self.channel.id, [self.link.id])
+
+    def test_station_dispatch_accepts_the_base_channel_permission(self):
+        url = reverse("trigger_station_dispatch",
+                      args=[self.link.id, self.channel.id])
+        self.login("change_dispatchchannel")
+
+        with patch("adl.core.views.perform_channel_dispatch") as task:
+            self.client.post(url)
+
+        task.delay.assert_called_once_with(self.channel.id, [self.link.id])
+
+    def test_test_connection_refuses_before_dialling_or_spending_a_press(self):
+        self.login()
+        url = self.channel_url("dispatch_channel_test_connection")
+
+        with patch("adl.core.views.run_dispatch_connection_test") as probe:
+            self.assertRefused(url)
+
+        probe.assert_not_called()
+        # The cooldown is claimed after the gate, so a refused press must
+        # not spend the budget a permitted operator is about to need
+        from adl.core.views import dispatch_test_cooldown_key
+        self.assertIsNone(cache.get(dispatch_test_cooldown_key(self.channel)))
+
+    def test_test_connection_dials_with_the_concrete_channel_permission(self):
+        self.login("change_wis2boxupload")
+        url = self.channel_url("dispatch_channel_test_connection")
+
+        with patch("adl.core.views.run_dispatch_connection_test") as probe:
+            probe.return_value = {"supported": True, "ok": True,
+                                  "message": "connected", "latency_ms": 12}
+            response = self.client.post(url)
+
+        probe.assert_called_once()
+        self.assertEqual(response.status_code, 302)
+
+    def test_test_connection_dials_with_the_base_channel_permission(self):
+        self.login("change_dispatchchannel")
+        url = self.channel_url("dispatch_channel_test_connection")
+
+        with patch("adl.core.views.run_dispatch_connection_test") as probe:
+            probe.return_value = {"supported": True, "ok": True,
+                                  "message": "connected", "latency_ms": 12}
+            self.client.post(url)
+
+        probe.assert_called_once()
+
+
+class ChannelButtonVisibilityTests(ManualActionTestCase):
+    """Hidden, not disabled — the source probe's precedent."""
+
+    def test_station_links_page_hides_the_action_forms(self):
+        self.login()
+
+        response = self.client.get(
+            reverse("dispatch_channel_station_links", args=[self.channel.id]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(
+            response, reverse("dispatch_channel_dispatch_now", args=[self.channel.id]))
+        self.assertNotContains(
+            response,
+            reverse("dispatch_channel_test_connection", args=[self.channel.id]))
+
+    def test_station_links_page_shows_the_action_forms_when_permitted(self):
+        self.login("change_wis2boxupload")
+
+        response = self.client.get(
+            reverse("dispatch_channel_station_links", args=[self.channel.id]))
+
+        self.assertContains(
+            response, reverse("dispatch_channel_dispatch_now", args=[self.channel.id]))
+
+    def test_locks_page_hides_the_reset_forms(self):
+        self.login()
+
+        with patch("adl.core.views.get_active_dispatch_tasks", return_value={}):
+            response = self.client.get(
+                reverse("dispatch_channel_locks", args=[self.channel.id]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(
+            response, reverse("dispatch_channel_reset", args=[self.channel.id]))
+
+    def test_locks_page_shows_the_reset_forms_when_permitted(self):
+        self.login("change_dispatchchannel")
+
+        with patch("adl.core.views.get_active_dispatch_tasks", return_value={}):
+            response = self.client.get(
+                reverse("dispatch_channel_locks", args=[self.channel.id]))
+
+        self.assertContains(
+            response, reverse("dispatch_channel_reset", args=[self.channel.id]))

--- a/adl/src/adl/core/views.py
+++ b/adl/src/adl/core/views.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 
 from django.contrib.gis.geos import Point
 from django.core.cache import cache
+from django.core.exceptions import PermissionDenied
 from django.core.paginator import Paginator, InvalidPage
 from django.db import transaction
 from django.shortcuts import render, redirect, get_object_or_404
@@ -52,6 +53,7 @@ from .models import (
     DispatchChannelStationLink,
     StationLink, Network
 )
+from .permissions import can_manage_channel, can_manage_connection
 from .plugin_utils import get_plugin_metadata
 from .probes import (
     PROBE_COOLDOWN_SECONDS,
@@ -1157,16 +1159,26 @@ def dispatch_channel_station_links(request, channel_id):
         "network_connections": network_connections,
         "heartbeat": getattr(channel, "heartbeat", None),
         "dispatch_overdue": channel.is_dispatch_overdue(),
+        # Hidden, not disabled, for a user who cannot take the action
+        "can_manage_channel": can_manage_channel(request.user, channel),
     }
     return render(request, "core/dispatch_channel_station_links.html", context=context)
 
 
 @require_http_methods(["POST"])
 def trigger_station_collection(request, station_link_id):
-    """Manually trigger data collection for a station link"""
+    """Manually trigger data collection for a station link.
+
+    Gated on the station link's *connection*, not the link: the connection
+    holds the credentials the run will use, and it is the object the
+    ingestion side's other manual actions are already gated on.
+    """
     if request.method == 'POST':
         station_link = get_object_or_404(StationLink, id=station_link_id)
-        
+
+        if not can_manage_connection(request.user, station_link.network_connection):
+            raise PermissionDenied
+
         try:
             # Trigger the collection task
             process_station_link_batch.delay(station_link.network_connection.id, [station_link.id])
@@ -1191,6 +1203,9 @@ def trigger_channel_dispatch(request, channel_id):
     """Manually trigger a dispatch run for all eligible stations on a channel"""
     if request.method == 'POST':
         dispatch_channel = get_object_or_404(DispatchChannel, id=channel_id)
+
+        if not can_manage_channel(request.user, dispatch_channel):
+            raise PermissionDenied
 
         try:
             perform_channel_dispatch.delay(dispatch_channel.id)
@@ -1279,6 +1294,8 @@ def dispatch_channel_locks(request, channel_id):
         "lock_rows": rows,
         "worker_responsive": worker_responsive,
         "stale_count": stale_count,
+        # Hidden, not disabled, for a user who cannot take the action
+        "can_manage_channel": can_manage_channel(request.user, channel),
     }
     return render(request, "core/dispatch_channel_locks.html", context=context)
 
@@ -1295,6 +1312,10 @@ def reset_channel_dispatch(request, channel_id):
     """
     if request.method == 'POST':
         dispatch_channel = get_object_or_404(DispatchChannel, id=channel_id)
+
+        if not can_manage_channel(request.user, dispatch_channel):
+            raise PermissionDenied
+
         scope = request.POST.get('scope', 'all')
 
         try:
@@ -1417,6 +1438,11 @@ def test_dispatch_channel_connection(request, channel_id):
     if request.method == 'POST':
         dispatch_channel = get_object_or_404(DispatchChannel, id=channel_id)
 
+        # Before the claim: a refused press must not spend the budget a
+        # permitted operator is about to need
+        if not can_manage_channel(request.user, dispatch_channel):
+            raise PermissionDenied
+
         now = dj_timezone.now()
         cooldown_key = dispatch_test_cooldown_key(dispatch_channel)
         if (channel_implements_test_connection(dispatch_channel)
@@ -1456,7 +1482,10 @@ def trigger_station_dispatch(request, station_link_id, channel_id):
     if request.method == 'POST':
         station_link = get_object_or_404(StationLink, id=station_link_id)
         dispatch_channel = get_object_or_404(DispatchChannel, id=channel_id)
-        
+
+        if not can_manage_channel(request.user, dispatch_channel):
+            raise PermissionDenied
+
         try:
             # Get data records for this station
             perform_channel_dispatch.delay(dispatch_channel.id, [station_link.id])

--- a/adl/src/adl/monitoring/tests/test_source_probe_view.py
+++ b/adl/src/adl/monitoring/tests/test_source_probe_view.py
@@ -81,6 +81,18 @@ class ProbePermissionTests(ProbeViewTestCase):
         self.assertContains(response, "do not have permission")
         self.assertEqual(xhr_response.status_code, 403)
 
+    def test_connection_change_permission_fires_the_probe(self):
+        # The same permission that gates the station-link page's manual
+        # collection trigger: one rule, so an operator never gets two
+        # verdicts about the same connection
+        self.client.force_login(self.make_plain_user("change_networkconnection"))
+
+        with patch("adl.monitoring.views.health.run_source_probe",
+                   return_value=OK_STEPS) as probe:
+            self.probe()
+
+        probe.assert_called_once()
+
     def test_button_is_hidden_not_disabled_for_unpermitted_users(self):
         self.client.force_login(self.make_plain_user())
 

--- a/adl/src/adl/monitoring/views/health.py
+++ b/adl/src/adl/monitoring/views/health.py
@@ -18,6 +18,7 @@ from adl.core.broker import (
     tested_range_display,
 )
 from adl.core.models import NetworkConnection, StationLink
+from adl.core.permissions import can_manage_connection
 from adl.core.probes import claim_probe_cooldown, read_probe_claim
 from adl.core.tasks import INGESTION_QUEUE_NAME, run_network_plugin
 from adl.core.source_checks import (
@@ -44,10 +45,10 @@ logger = logging.getLogger(__name__)
 # window: equalising them would make an operator wait 15 minutes to verify a
 # password fix.
 
-# The permission that gates the probe: someone who can edit a host and its
-# credentials can already make the runtime dial them, and a new permission
-# would have to be discovered and assigned across 26 deployments
-PROBE_PERMISSION = "core.change_networkconnection"
+# The permission that gates the probe is the connection's own change
+# permission — see `adl.core.permissions`, which is also what gates the
+# station-link page's manual collection trigger. One rule, so the same user
+# never gets two verdicts about the same connection.
 
 # The manual re-run cooldown is the connection's own processing interval,
 # capped here — deliberately stricter than the probe's 60 seconds: one press
@@ -143,7 +144,7 @@ def connection_health(request, connection_id):
     # enabled during cooldown: the shared result is the limit, and a
     # countdown would reintroduce the refusal that was rejected
     show_probe_button = (
-        request.user.has_perm(PROBE_PERMISSION)
+        can_manage_connection(request.user, connection)
         and connection.source_probe_supported
     )
 
@@ -217,7 +218,7 @@ def connection_health(request, connection_id):
         "layer_groups": layer_groups,
         # Hidden rather than disabled, like the probe button — and hidden on
         # a disabled connection: there is nothing to run
-        "show_run_button": (request.user.has_perm(PROBE_PERMISSION)
+        "show_run_button": (can_manage_connection(request.user, connection)
                             and connection.enabled),
         "latest_run_was_manual": latest_run_was_manual(heartbeat),
         "heartbeat": heartbeat,
@@ -245,7 +246,7 @@ def connection_probe_source(request, connection_id):
     """
     connection = get_object_or_404(NetworkConnection, id=connection_id)
 
-    if not request.user.has_perm(PROBE_PERMISSION):
+    if not can_manage_connection(request.user, connection):
         raise PermissionDenied
 
     diagnostic_page = redirect("connection_health", connection_id=connection.id)
@@ -363,7 +364,7 @@ def connection_run_now(request, connection_id):
     """
     connection = get_object_or_404(NetworkConnection, id=connection_id)
 
-    if not request.user.has_perm(PROBE_PERMISSION):
+    if not can_manage_connection(request.user, connection):
         raise PermissionDenied
 
     diagnostic_page = redirect("connection_health", connection_id=connection.id)
@@ -447,7 +448,7 @@ def station_link_check_source(request, link_id):
     """
     station_link = get_object_or_404(StationLink, id=link_id)
 
-    if not request.user.has_perm(PROBE_PERMISSION):
+    if not can_manage_connection(request.user, station_link.network_connection):
         raise PermissionDenied
 
     inspect_page = _station_link_page(station_link)


### PR DESCRIPTION
Closes #163.

## Problem

Five manual-action views in `core/views.py` are registered through `register_admin_urls`, which Wagtail wraps in `require_admin_access` — and they performed no check of their own. The effective gate was **"any user who can log into the Wagtail admin"**, including one provisioned purely to read the monitoring pages.

`reset_channel_dispatch` is the sharpest: it deletes the per-station locks that prevent concurrent double-dispatch. `test_dispatch_channel_connection` dials a partner's infrastructure synchronously from the web process.

## The gate

Each view now raises `PermissionDenied` unless the user holds the change permission for the object being acted on — rather than a dedicated permission that 26 deployments would have to discover and assign.

| View | Gated on |
|---|---|
| `trigger_station_collection` | the link's **connection** — it holds the credentials the run will use |
| `trigger_channel_dispatch` | the **channel** |
| `reset_channel_dispatch` | the **channel** |
| `test_dispatch_channel_connection` | the **channel** (checked *before* the cooldown claim, so a refused press cannot spend the budget a permitted operator is about to need) |
| `trigger_station_dispatch` | the **channel** |

Buttons are hidden rather than disabled, following the source probe. On the station-link panel the dispatch button is resolved per channel — a user may hold the change permission on one channel type and not another.

## Concrete subclass *or* base

Both models are polymorphic and the admin registers a viewset per **concrete subclass**, so `change_wis2boxupload` is what a deployment actually grants a channel operator; `change_dispatchchannel` is what a superuser or a deliberately-global group holds. The rule accepts either.

Gating on the base alone — as #163's suggested direction literally reads — would have left the buttons working for nobody but a superuser, which is the outcome the issue's own "no new permission to assign across 26 deployments" reasoning exists to avoid.

## One change beyond the ticket — please review this bit

The rule lives in a new `core/permissions.py`, and `monitoring/views/health.py` now reads it too.

Without that, the probe/run gate (`PROBE_PERMISSION`, a flat `"core.change_networkconnection"` string from #160) and the new collection-trigger gate would give **different answers about the same connection on the same page**: an operator holding only `change_ftpconnection` could trigger a collection but would see no source-probe button.

This slightly widens #160's shipped gate. The alternative was to narrow the new gate to superuser-only. Happy to revert to the narrow version if you'd rather leave #160's decision untouched — it is a one-line change in `health.py`.

## Testing

- 536 tests pass (up from 530; 24 new).
- The permission tests were written red-first: 10 of 18 failed before the gate existed.
- New `core/tests/test_manual_action_permissions.py` exercises each action three ways — refused for an admin-access user with no change rights, allowed for the concrete subclass permission, allowed for the polymorphic base — and asserts on the side effect (task enqueued, locks cleared, destination dialled), not on the helper alone.
- Button visibility is covered on both channel pages and the station-link panel.
- A new test in `test_source_probe_view.py` pins the parity above.

## Not in scope

- `test_dispatch_channel_connection`'s cooldown, which #163 left as a separate call — it already landed at HEAD via #213/#215.
- Pre-existing inline styles in the two touched templates, recorded as known debt in `template_conventions.md`.