### PR TITLE
fix: delete a connection's or channel's beat schedule with it

### DIFF
--- a/adl/src/adl/core/apps.py
+++ b/adl/src/adl/core/apps.py
@@ -1,22 +1,38 @@
 from django.apps import AppConfig
-from django.db.models.signals import post_save
+from django.db.models.signals import post_delete, post_save
 
 
 class CoreConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'adl.core'
-    
+
     def ready(self):
         from .models import NetworkConnection, DispatchChannel
-        from .tasks import update_network_plugin_periodic_task, update_dispatch_channel_periodic_tasks
-        
+        from .tasks import (
+            delete_dispatch_channel_periodic_tasks,
+            delete_network_plugin_periodic_tasks,
+            update_dispatch_channel_periodic_tasks,
+            update_network_plugin_periodic_task,
+        )
+
         # update plugin periodic task when a network connection plugin is saved
         network_connection_models = NetworkConnection.__subclasses__()
         for model in network_connection_models:
             post_save.connect(update_network_plugin_periodic_task, sender=model)
-        
+
         # update dispatch channel period tasks when DispatchChannel is saved
         dispatch_channel_models = DispatchChannel.__subclasses__()
-        
+
         for model in dispatch_channel_models:
             post_save.connect(update_dispatch_channel_periodic_tasks, sender=model)
+
+        # A deleted connection or channel must take its beat schedule entry
+        # with it — otherwise the entry stays enabled and keeps firing against
+        # an id that no longer exists. The base models are connected alongside
+        # the subclasses so a delete issued through the base manager is covered
+        # too; the receivers are idempotent, so being called twice is a no-op.
+        for model in [NetworkConnection, *network_connection_models]:
+            post_delete.connect(delete_network_plugin_periodic_tasks, sender=model)
+
+        for model in [DispatchChannel, *dispatch_channel_models]:
+            post_delete.connect(delete_dispatch_channel_periodic_tasks, sender=model)

--- a/adl/src/adl/core/management/commands/prune_orphaned_periodic_tasks.py
+++ b/adl/src/adl/core/management/commands/prune_orphaned_periodic_tasks.py
@@ -26,6 +26,10 @@ class Command(BaseCommand):
             self.stdout.write(self.style.SUCCESS("No orphaned schedule entries found."))
             return
 
+        # The delete has already happened by this point, so the listing is a
+        # record of what went, not a preview of what will
+        self.stdout.write("Would remove:" if dry_run else "Removed:")
+
         for entry in orphans:
             self.stdout.write(f"  {entry.task} args={entry.args} (name={entry.name})")
 

--- a/adl/src/adl/core/management/commands/prune_orphaned_periodic_tasks.py
+++ b/adl/src/adl/core/management/commands/prune_orphaned_periodic_tasks.py
@@ -1,0 +1,40 @@
+from django.core.management.base import BaseCommand
+
+from adl.core.tasks import prune_orphaned_periodic_tasks
+
+
+class Command(BaseCommand):
+    help = (
+        "Remove beat schedule entries for network connections and dispatch "
+        "channels that no longer exist. New deletes are cleaned up by signal; "
+        "this is for orphans a deployment accumulated before that existed."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--dry-run',
+            action='store_true',
+            help='List the orphaned entries without deleting them',
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options.get('dry_run', False)
+
+        orphans = prune_orphaned_periodic_tasks(dry_run=dry_run)
+
+        if not orphans:
+            self.stdout.write(self.style.SUCCESS("No orphaned schedule entries found."))
+            return
+
+        for entry in orphans:
+            self.stdout.write(f"  {entry.task} args={entry.args} (name={entry.name})")
+
+        if dry_run:
+            self.stdout.write(self.style.WARNING(
+                f"\nDRY RUN - {len(orphans)} entries would be removed. No changes made."
+            ))
+            return
+
+        self.stdout.write(self.style.SUCCESS(
+            f"\nRemoved {len(orphans)} orphaned schedule entries."
+        ))

--- a/adl/src/adl/core/tasks.py
+++ b/adl/src/adl/core/tasks.py
@@ -484,10 +484,10 @@ class ConnectionScheduleEntries:
         return self.entries[0] if self.entries else None
 
 
-def find_periodic_tasks_for(task_name, object_id):
+def iter_owned_schedule_entries(task_name):
     """
-    Every beat schedule entry that runs ``task_name`` for ``object_id``,
-    oldest first.
+    Every beat schedule entry running ``task_name`` whose owner can be read,
+    oldest first, as ``(entry, owner_id)``.
 
     Entries are resolved by *what they run* — the task name plus its args —
     never by the generated ``repr(sig)`` name. Matching on the generated name
@@ -496,17 +496,55 @@ def find_periodic_tasks_for(task_name, object_id):
     invisible. Matching on task + args makes both visible. Args are compared
     parsed, not as strings, so whitespace or an unparseable value cannot
     masquerade as a miss or raise.
+
+    Entries whose args cannot be read are skipped rather than yielded with a
+    null owner: there is nothing to match or check them against, so every
+    caller would only have to drop them again.
     """
-    matched = []
-    for candidate in PeriodicTask.objects.filter(task=task_name).order_by("id"):
+    for entry in PeriodicTask.objects.filter(task=task_name).order_by("id"):
         try:
-            args = json.loads(candidate.args or "[]")
+            args = json.loads(entry.args or "[]")
         except (TypeError, ValueError):
             continue
-        if isinstance(args, list) and args and args[0] == object_id:
-            matched.append(candidate)
+        if not isinstance(args, list) or not args:
+            continue
 
-    return matched
+        owner_id = _read_owner_id(args[0])
+        if owner_id is not None:
+            yield entry, owner_id
+
+
+def _read_owner_id(value):
+    """
+    The object id an entry's first arg names, or ``None`` when it names none.
+
+    A hand-written row can carry ``["5"]`` rather than ``[5]``. Compared raw
+    that reads as a different object — the writer would add a duplicate and
+    the prune would delete a live object's entry — so ids are normalised to
+    int here, once, for every caller.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return None
+    return None
+
+
+def find_periodic_tasks_for(task_name, object_id):
+    """
+    Every beat schedule entry that runs ``task_name`` for ``object_id``,
+    oldest first.
+    """
+    return [
+        entry
+        for entry, owner_id in iter_owned_schedule_entries(task_name)
+        if owner_id == object_id
+    ]
 
 
 def find_connection_schedule_entries(network_connection):
@@ -526,6 +564,11 @@ def _write_periodic_task(task_name, object_id, name, interval, enabled, queue):
     shadowed by a second, still-enabled row. Any surplus rows for the same
     object are removed here — the writer is the one place that can collapse
     duplicates back to one without guessing which one beat is firing.
+
+    A drifted ``name`` is deliberately left as it is: ``name`` is what an
+    operator recognises the row by in the beat admin, nothing reads it, and
+    rewriting it could collide with the unique name of an unrelated row.
+    ``name`` is used only when creating.
     """
     schedule, _ = IntervalSchedule.objects.get_or_create(
         every=interval,
@@ -842,6 +885,12 @@ def prune_orphaned_periodic_tasks(dry_run=False):
     Entries whose args cannot be read are left alone: there is no owner to
     check them against, so deleting them would be a guess. Returns the pruned
     entries so a dry run can report exactly what a real run would remove.
+
+    Ownership is re-checked against the database immediately before the
+    delete. Scanning every entry takes long enough for a connection to be
+    created in the meantime, and its brand-new schedule entry would otherwise
+    be judged against a snapshot taken before it existed — the command would
+    delete the schedule of a live connection.
     """
     from .models import DispatchChannel, NetworkConnection
 
@@ -854,15 +903,24 @@ def prune_orphaned_periodic_tasks(dry_run=False):
     for task_name, model in owners:
         live_ids = set(model.objects.values_list("id", flat=True))
 
-        for candidate in PeriodicTask.objects.filter(task=task_name).order_by("id"):
-            try:
-                args = json.loads(candidate.args or "[]")
-            except (TypeError, ValueError):
-                continue
-            if not isinstance(args, list) or not args:
-                continue
-            if args[0] not in live_ids:
-                orphans.append(candidate)
+        candidates = [
+            (entry, owner_id)
+            for entry, owner_id in iter_owned_schedule_entries(task_name)
+            if owner_id not in live_ids
+        ]
+
+        if not candidates:
+            continue
+
+        born_since = set(
+            model.objects.filter(
+                id__in=[owner_id for _, owner_id in candidates]
+            ).values_list("id", flat=True)
+        )
+
+        orphans.extend(
+            entry for entry, owner_id in candidates if owner_id not in born_since
+        )
 
     if orphans and not dry_run:
         PeriodicTask.objects.filter(id__in=[entry.id for entry in orphans]).delete()

--- a/adl/src/adl/core/tasks.py
+++ b/adl/src/adl/core/tasks.py
@@ -41,6 +41,10 @@ INGESTION_TASK_NAME = "adl.core.tasks.run_network_plugin"
 # Everything that recognises ingestion work on the queue matches on this
 INGESTION_BATCH_TASK_NAME = "adl.core.tasks.process_station_link_batch"
 
+# The registered name of the dispatch task. A channel's beat schedule entries
+# are resolved by this plus their args, exactly as ingestion's are
+DISPATCH_TASK_NAME = "adl.core.tasks.perform_channel_dispatch"
+
 # Extra time allowed beyond the soft limit before the worker hard-kills a
 # station dispatch task
 DISPATCH_TIME_LIMIT_GRACE_SECONDS = 30
@@ -480,57 +484,122 @@ class ConnectionScheduleEntries:
         return self.entries[0] if self.entries else None
 
 
-def find_connection_schedule_entries(network_connection):
+def find_periodic_tasks_for(task_name, object_id):
     """
-    Resolve a connection's ingestion schedule entries by *what they run* — the
-    task name plus its args — never by the generated ``repr(sig)`` name.
+    Every beat schedule entry that runs ``task_name`` for ``object_id``,
+    oldest first.
 
-    Matching on the generated name means a row whose name drifted (a Celery
-    upgrade, a hand edit) reads as absent while it keeps firing, and a second
-    row for the same connection is invisible. Matching on task + args makes
-    both visible. Args are compared parsed, not as strings, so whitespace or
-    an unparseable value cannot masquerade as a miss or raise.
+    Entries are resolved by *what they run* — the task name plus its args —
+    never by the generated ``repr(sig)`` name. Matching on the generated name
+    means a row whose name drifted (a Celery upgrade, a hand edit) reads as
+    absent while it keeps firing, and a second row for the same object is
+    invisible. Matching on task + args makes both visible. Args are compared
+    parsed, not as strings, so whitespace or an unparseable value cannot
+    masquerade as a miss or raise.
     """
-    candidates = PeriodicTask.objects.filter(task=INGESTION_TASK_NAME).order_by("id")
-
     matched = []
-    for candidate in candidates:
+    for candidate in PeriodicTask.objects.filter(task=task_name).order_by("id"):
         try:
             args = json.loads(candidate.args or "[]")
         except (TypeError, ValueError):
             continue
-        if isinstance(args, list) and args and args[0] == network_connection.id:
+        if isinstance(args, list) and args and args[0] == object_id:
             matched.append(candidate)
 
-    return ConnectionScheduleEntries(entries=tuple(matched))
+    return matched
 
 
-def create_or_update_network_plugin_periodic_tasks(network_connection):
-    interval = network_connection.plugin_processing_interval
-    enabled = network_connection.plugin_processing_enabled
-    
-    sig = run_network_plugin.s(network_connection.id)
-    name = repr(sig)
-    
-    # Create or update the periodic task
-    schedule, created = IntervalSchedule.objects.get_or_create(
+def find_connection_schedule_entries(network_connection):
+    """A connection's ingestion schedule entries, with the faults named."""
+    entries = find_periodic_tasks_for(INGESTION_TASK_NAME, network_connection.id)
+
+    return ConnectionScheduleEntries(entries=tuple(entries))
+
+
+def _write_periodic_task(task_name, object_id, name, interval, enabled, queue):
+    """
+    Make the beat schedule hold exactly one entry running ``task_name`` for
+    ``object_id``.
+
+    The existing entry is found by task + args rather than by ``name``, so a
+    row whose generated name drifted is updated in place instead of being
+    shadowed by a second, still-enabled row. Any surplus rows for the same
+    object are removed here — the writer is the one place that can collapse
+    duplicates back to one without guessing which one beat is firing.
+    """
+    schedule, _ = IntervalSchedule.objects.get_or_create(
         every=interval,
         period=IntervalSchedule.MINUTES,
     )
-    PeriodicTask.objects.update_or_create(
-        name=name,
-        defaults={
-            'interval': schedule,
-            'task': sig.name,
-            'args': json.dumps([network_connection.id]),
-            'enabled': enabled,
-            'queue': INGESTION_QUEUE_NAME,
-        }
+    defaults = {
+        'interval': schedule,
+        'task': task_name,
+        'args': json.dumps([object_id]),
+        'enabled': enabled,
+        'queue': queue,
+    }
+
+    existing = find_periodic_tasks_for(task_name, object_id)
+
+    if not existing:
+        # Keyed on name so a row we could not match on args (unreadable args,
+        # say) is rewritten rather than colliding on the unique name
+        PeriodicTask.objects.update_or_create(name=name, defaults=defaults)
+        return
+
+    entry, *duplicates = existing
+    for field, value in defaults.items():
+        setattr(entry, field, value)
+    entry.save()
+
+    if duplicates:
+        logger.warning(
+            "Removing %d duplicate schedule entries for %s(%s)",
+            len(duplicates), task_name, object_id,
+        )
+        PeriodicTask.objects.filter(id__in=[row.id for row in duplicates]).delete()
+
+
+def _delete_periodic_tasks(task_name, object_id):
+    """Drop every schedule entry running ``task_name`` for ``object_id``."""
+    entries = find_periodic_tasks_for(task_name, object_id)
+
+    if not entries:
+        return 0
+
+    PeriodicTask.objects.filter(id__in=[entry.id for entry in entries]).delete()
+
+    return len(entries)
+
+
+def create_or_update_network_plugin_periodic_tasks(network_connection):
+    _write_periodic_task(
+        INGESTION_TASK_NAME,
+        network_connection.id,
+        name=repr(run_network_plugin.s(network_connection.id)),
+        interval=network_connection.plugin_processing_interval,
+        enabled=network_connection.plugin_processing_enabled,
+        queue=INGESTION_QUEUE_NAME,
     )
 
 
 def update_network_plugin_periodic_task(sender, instance, **kwargs):
     create_or_update_network_plugin_periodic_tasks(instance)
+
+
+def delete_network_plugin_periodic_tasks(sender, instance, **kwargs):
+    """
+    A deleted connection must take its schedule with it. Left behind, the
+    entry stays enabled and beat keeps dispatching ingestion for an id nobody
+    can see in the admin.
+    """
+    removed = _delete_periodic_tasks(INGESTION_TASK_NAME, instance.id)
+
+    if removed:
+        logger.info(
+            "Removed %d schedule entries for deleted network connection %s",
+            removed, instance.id,
+        )
 
 
 # Deliberately NOT a Singleton task: a stale singleton lock silently discards
@@ -735,29 +804,67 @@ def sweep_stale_activity_logs():
 
 
 def create_or_update_dispatch_channel_periodic_tasks(dispatch_channel):
-    interval = dispatch_channel.data_check_interval
-    enabled = dispatch_channel.enabled
-    
-    sig = perform_channel_dispatch.s(dispatch_channel.id)
-    name = repr(sig)
-    
-    # Create or update the periodic task
-    schedule, created = IntervalSchedule.objects.get_or_create(
-        every=interval,
-        period=IntervalSchedule.MINUTES,
-    )
-    
-    PeriodicTask.objects.update_or_create(
-        name=name,
-        defaults={
-            'interval': schedule,
-            'task': sig.name,
-            'args': json.dumps([dispatch_channel.id]),
-            'enabled': enabled,
-            'queue': DISPATCH_QUEUE_NAME,
-        }
+    _write_periodic_task(
+        DISPATCH_TASK_NAME,
+        dispatch_channel.id,
+        name=repr(perform_channel_dispatch.s(dispatch_channel.id)),
+        interval=dispatch_channel.data_check_interval,
+        enabled=dispatch_channel.enabled,
+        queue=DISPATCH_QUEUE_NAME,
     )
 
 
 def update_dispatch_channel_periodic_tasks(sender, instance, **kwargs):
     create_or_update_dispatch_channel_periodic_tasks(instance)
+
+
+def delete_dispatch_channel_periodic_tasks(sender, instance, **kwargs):
+    """
+    A deleted channel must take its schedule with it. Unlike ingestion,
+    ``perform_channel_dispatch`` raises on a missing channel, so an orphaned
+    entry is a recurring hard task failure rather than quiet log noise.
+    """
+    removed = _delete_periodic_tasks(DISPATCH_TASK_NAME, instance.id)
+
+    if removed:
+        logger.info(
+            "Removed %d schedule entries for deleted dispatch channel %s",
+            removed, instance.id,
+        )
+
+
+def prune_orphaned_periodic_tasks(dry_run=False):
+    """
+    Drop ingestion and dispatch schedule entries whose object no longer
+    exists — the retrospective counterpart to the post_delete receivers, for
+    deployments that accumulated orphans before those existed.
+
+    Entries whose args cannot be read are left alone: there is no owner to
+    check them against, so deleting them would be a guess. Returns the pruned
+    entries so a dry run can report exactly what a real run would remove.
+    """
+    from .models import DispatchChannel, NetworkConnection
+
+    owners = (
+        (INGESTION_TASK_NAME, NetworkConnection),
+        (DISPATCH_TASK_NAME, DispatchChannel),
+    )
+
+    orphans = []
+    for task_name, model in owners:
+        live_ids = set(model.objects.values_list("id", flat=True))
+
+        for candidate in PeriodicTask.objects.filter(task=task_name).order_by("id"):
+            try:
+                args = json.loads(candidate.args or "[]")
+            except (TypeError, ValueError):
+                continue
+            if not isinstance(args, list) or not args:
+                continue
+            if args[0] not in live_ids:
+                orphans.append(candidate)
+
+    if orphans and not dry_run:
+        PeriodicTask.objects.filter(id__in=[entry.id for entry in orphans]).delete()
+
+    return orphans

--- a/adl/src/adl/core/tests/test_periodic_task_lifecycle.py
+++ b/adl/src/adl/core/tests/test_periodic_task_lifecycle.py
@@ -1,0 +1,271 @@
+import json
+from io import StringIO
+
+from django.core.management import call_command
+from django.test import TestCase
+from django_celery_beat.models import IntervalSchedule, PeriodicTask
+
+from adl.core.tasks import (
+    DISPATCH_TASK_NAME,
+    INGESTION_TASK_NAME,
+    create_or_update_dispatch_channel_periodic_tasks,
+    create_or_update_network_plugin_periodic_tasks,
+    delete_dispatch_channel_periodic_tasks,
+    delete_network_plugin_periodic_tasks,
+    find_periodic_tasks_for,
+    prune_orphaned_periodic_tasks,
+)
+from .factories import NetworkConnectionFactory, Wis2BoxUploadFactory
+
+
+def add_entry(task_name, object_id, name, args=None):
+    schedule, _ = IntervalSchedule.objects.get_or_create(
+        every=15, period=IntervalSchedule.MINUTES
+    )
+    return PeriodicTask.objects.create(
+        name=name,
+        interval=schedule,
+        task=task_name,
+        args=args if args is not None else json.dumps([object_id]),
+    )
+
+
+class IngestionScheduleWriterTests(TestCase):
+    def setUp(self):
+        self.connection = NetworkConnectionFactory()
+        PeriodicTask.objects.filter(task=INGESTION_TASK_NAME).delete()
+
+    def entries(self):
+        return find_periodic_tasks_for(INGESTION_TASK_NAME, self.connection.id)
+
+    def test_first_write_creates_one_entry(self):
+        create_or_update_network_plugin_periodic_tasks(self.connection)
+
+        entries = self.entries()
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(json.loads(entries[0].args), [self.connection.id])
+        self.assertTrue(entries[0].enabled)
+
+    def test_repeated_writes_do_not_accumulate_entries(self):
+        create_or_update_network_plugin_periodic_tasks(self.connection)
+        create_or_update_network_plugin_periodic_tasks(self.connection)
+
+        self.assertEqual(len(self.entries()), 1)
+
+    def test_a_drifted_name_is_updated_rather_than_duplicated(self):
+        # The row was written by another Celery build, so its generated name
+        # no longer matches repr(sig). It still runs this connection.
+        drifted = add_entry(INGESTION_TASK_NAME, self.connection.id, "old-format-name")
+        self.connection.plugin_processing_enabled = False
+        self.connection.save()
+
+        create_or_update_network_plugin_periodic_tasks(self.connection)
+
+        entries = self.entries()
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0].id, drifted.id)
+        self.assertFalse(entries[0].enabled)
+
+    def test_pre_existing_duplicates_collapse_to_one(self):
+        first = add_entry(INGESTION_TASK_NAME, self.connection.id, "dup-a")
+        add_entry(INGESTION_TASK_NAME, self.connection.id, "dup-b")
+
+        create_or_update_network_plugin_periodic_tasks(self.connection)
+
+        entries = self.entries()
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0].id, first.id)
+
+    def test_another_connections_entry_is_untouched(self):
+        other = NetworkConnectionFactory()
+        add_entry(INGESTION_TASK_NAME, other.id, "run-other")
+
+        create_or_update_network_plugin_periodic_tasks(self.connection)
+
+        self.assertEqual(len(find_periodic_tasks_for(INGESTION_TASK_NAME, other.id)), 1)
+
+
+class IngestionScheduleDeletionTests(TestCase):
+    def setUp(self):
+        self.connection = NetworkConnectionFactory()
+        PeriodicTask.objects.filter(task=INGESTION_TASK_NAME).delete()
+
+    def test_deleting_a_connection_removes_its_schedule_entry(self):
+        create_or_update_network_plugin_periodic_tasks(self.connection)
+        connection_id = self.connection.id
+
+        self.connection.delete()
+
+        self.assertEqual(find_periodic_tasks_for(INGESTION_TASK_NAME, connection_id), [])
+
+    def test_deleting_a_connection_removes_every_duplicate_entry(self):
+        add_entry(INGESTION_TASK_NAME, self.connection.id, "dup-a")
+        add_entry(INGESTION_TASK_NAME, self.connection.id, "dup-b")
+        connection_id = self.connection.id
+
+        self.connection.delete()
+
+        self.assertEqual(find_periodic_tasks_for(INGESTION_TASK_NAME, connection_id), [])
+
+    def test_deleting_a_connection_leaves_other_connections_entries(self):
+        other = NetworkConnectionFactory()
+        create_or_update_network_plugin_periodic_tasks(self.connection)
+        create_or_update_network_plugin_periodic_tasks(other)
+
+        self.connection.delete()
+
+        self.assertEqual(len(find_periodic_tasks_for(INGESTION_TASK_NAME, other.id)), 1)
+
+    def test_the_receiver_is_a_no_op_when_there_is_no_entry(self):
+        delete_network_plugin_periodic_tasks(
+            sender=type(self.connection), instance=self.connection
+        )
+
+        self.assertEqual(PeriodicTask.objects.filter(task=INGESTION_TASK_NAME).count(), 0)
+
+
+class DispatchScheduleLifecycleTests(TestCase):
+    def setUp(self):
+        PeriodicTask.objects.filter(task=DISPATCH_TASK_NAME).delete()
+
+    def test_saving_a_channel_writes_one_entry(self):
+        channel = Wis2BoxUploadFactory()
+
+        entries = find_periodic_tasks_for(DISPATCH_TASK_NAME, channel.id)
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0].queue, "dispatch")
+
+    def test_a_drifted_name_is_updated_rather_than_duplicated(self):
+        channel = Wis2BoxUploadFactory()
+        PeriodicTask.objects.filter(task=DISPATCH_TASK_NAME).delete()
+        drifted = add_entry(DISPATCH_TASK_NAME, channel.id, "old-format-name")
+
+        create_or_update_dispatch_channel_periodic_tasks(channel)
+
+        entries = find_periodic_tasks_for(DISPATCH_TASK_NAME, channel.id)
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0].id, drifted.id)
+
+    def test_deleting_a_channel_removes_its_schedule_entry(self):
+        channel = Wis2BoxUploadFactory()
+        channel_id = channel.id
+
+        channel.delete()
+
+        self.assertEqual(find_periodic_tasks_for(DISPATCH_TASK_NAME, channel_id), [])
+
+    def test_the_receiver_is_a_no_op_when_there_is_no_entry(self):
+        channel = Wis2BoxUploadFactory()
+        PeriodicTask.objects.filter(task=DISPATCH_TASK_NAME).delete()
+
+        delete_dispatch_channel_periodic_tasks(sender=type(channel), instance=channel)
+
+        self.assertEqual(PeriodicTask.objects.filter(task=DISPATCH_TASK_NAME).count(), 0)
+
+
+class FindPeriodicTasksForTests(TestCase):
+    def setUp(self):
+        self.connection = NetworkConnectionFactory()
+        PeriodicTask.objects.filter(task=INGESTION_TASK_NAME).delete()
+
+    def test_unparseable_args_are_ignored_rather_than_raising(self):
+        add_entry(INGESTION_TASK_NAME, self.connection.id, "broken", args="not-json")
+
+        self.assertEqual(find_periodic_tasks_for(INGESTION_TASK_NAME, self.connection.id), [])
+
+    def test_a_different_task_with_the_same_id_is_not_matched(self):
+        add_entry(DISPATCH_TASK_NAME, self.connection.id, "dispatch-entry")
+
+        self.assertEqual(find_periodic_tasks_for(INGESTION_TASK_NAME, self.connection.id), [])
+
+    def test_entries_are_returned_in_creation_order(self):
+        first = add_entry(INGESTION_TASK_NAME, self.connection.id, "a")
+        second = add_entry(INGESTION_TASK_NAME, self.connection.id, "b")
+
+        self.assertEqual(
+            [entry.id for entry in find_periodic_tasks_for(INGESTION_TASK_NAME, self.connection.id)],
+            [first.id, second.id],
+        )
+
+
+class PruneOrphanedPeriodicTasksTests(TestCase):
+    """
+    The retrospective cleanup for deployments that already accumulated
+    orphans before the post_delete receivers existed.
+    """
+
+    def setUp(self):
+        PeriodicTask.objects.filter(
+            task__in=[INGESTION_TASK_NAME, DISPATCH_TASK_NAME]
+        ).delete()
+
+    def test_an_entry_for_a_deleted_connection_is_pruned(self):
+        connection = NetworkConnectionFactory()
+        create_or_update_network_plugin_periodic_tasks(connection)
+        orphan_id = connection.id
+        PeriodicTask.objects.filter(task=INGESTION_TASK_NAME).update(name="orphan")
+        NetworkConnectionFactory._meta.model.objects.filter(id=orphan_id).delete()
+        # re-create the row the delete receiver just removed, as a pre-fix
+        # deployment would have left it behind
+        add_entry(INGESTION_TASK_NAME, orphan_id, "left-behind")
+
+        pruned = prune_orphaned_periodic_tasks()
+
+        self.assertEqual(find_periodic_tasks_for(INGESTION_TASK_NAME, orphan_id), [])
+        self.assertEqual(len(pruned), 1)
+
+    def test_an_entry_for_a_live_connection_is_kept(self):
+        connection = NetworkConnectionFactory()
+        create_or_update_network_plugin_periodic_tasks(connection)
+
+        prune_orphaned_periodic_tasks()
+
+        self.assertEqual(len(find_periodic_tasks_for(INGESTION_TASK_NAME, connection.id)), 1)
+
+    def test_an_entry_for_a_live_dispatch_channel_is_kept(self):
+        channel = Wis2BoxUploadFactory()
+
+        prune_orphaned_periodic_tasks()
+
+        self.assertEqual(len(find_periodic_tasks_for(DISPATCH_TASK_NAME, channel.id)), 1)
+
+    def test_a_dry_run_reports_without_deleting(self):
+        add_entry(INGESTION_TASK_NAME, 999999, "left-behind")
+
+        pruned = prune_orphaned_periodic_tasks(dry_run=True)
+
+        self.assertEqual(len(pruned), 1)
+        self.assertEqual(len(find_periodic_tasks_for(INGESTION_TASK_NAME, 999999)), 1)
+
+    def test_an_unrelated_task_is_never_pruned(self):
+        add_entry("some.other.task", 999999, "unrelated")
+
+        prune_orphaned_periodic_tasks()
+
+        self.assertTrue(PeriodicTask.objects.filter(name="unrelated").exists())
+
+    def test_the_management_command_removes_orphans(self):
+        add_entry(INGESTION_TASK_NAME, 999999, "left-behind")
+        out = StringIO()
+
+        call_command("prune_orphaned_periodic_tasks", stdout=out)
+
+        self.assertEqual(len(find_periodic_tasks_for(INGESTION_TASK_NAME, 999999)), 0)
+        self.assertIn("Removed 1", out.getvalue())
+
+    def test_the_management_command_honours_dry_run(self):
+        add_entry(INGESTION_TASK_NAME, 999999, "left-behind")
+        out = StringIO()
+
+        call_command("prune_orphaned_periodic_tasks", "--dry-run", stdout=out)
+
+        self.assertEqual(len(find_periodic_tasks_for(INGESTION_TASK_NAME, 999999)), 1)
+        self.assertIn("DRY RUN", out.getvalue())
+
+    def test_an_entry_with_unreadable_args_is_left_alone(self):
+        add_entry(INGESTION_TASK_NAME, None, "unreadable", args="not-json")
+
+        pruned = prune_orphaned_periodic_tasks()
+
+        self.assertTrue(PeriodicTask.objects.filter(name="unreadable").exists())
+        self.assertEqual(pruned, [])

--- a/adl/src/adl/core/tests/test_periodic_task_lifecycle.py
+++ b/adl/src/adl/core/tests/test_periodic_task_lifecycle.py
@@ -1,10 +1,12 @@
 import json
 from io import StringIO
+from unittest.mock import patch
 
 from django.core.management import call_command
 from django.test import TestCase
 from django_celery_beat.models import IntervalSchedule, PeriodicTask
 
+from adl.core import tasks
 from adl.core.tasks import (
     DISPATCH_TASK_NAME,
     INGESTION_TASK_NAME,
@@ -178,6 +180,25 @@ class FindPeriodicTasksForTests(TestCase):
 
         self.assertEqual(find_periodic_tasks_for(INGESTION_TASK_NAME, self.connection.id), [])
 
+    def test_a_string_id_matches_the_object_it_names(self):
+        # A hand-written row can carry ["5"] rather than [5]; compared raw it
+        # would read as a different object and the writer would duplicate it
+        add_entry(
+            INGESTION_TASK_NAME,
+            self.connection.id,
+            "string-id",
+            args=json.dumps([str(self.connection.id)]),
+        )
+
+        self.assertEqual(
+            len(find_periodic_tasks_for(INGESTION_TASK_NAME, self.connection.id)), 1
+        )
+
+    def test_an_id_that_names_no_object_is_ignored(self):
+        add_entry(INGESTION_TASK_NAME, None, "not-an-id", args=json.dumps(["abc"]))
+
+        self.assertEqual(find_periodic_tasks_for(INGESTION_TASK_NAME, self.connection.id), [])
+
     def test_entries_are_returned_in_creation_order(self):
         first = add_entry(INGESTION_TASK_NAME, self.connection.id, "a")
         second = add_entry(INGESTION_TASK_NAME, self.connection.id, "b")
@@ -243,6 +264,41 @@ class PruneOrphanedPeriodicTasksTests(TestCase):
         prune_orphaned_periodic_tasks()
 
         self.assertTrue(PeriodicTask.objects.filter(name="unrelated").exists())
+
+    def test_an_entry_whose_owner_appears_mid_scan_is_kept(self):
+        # A connection created after the live-id snapshot has its entry
+        # written by post_save; judged against that stale snapshot it would
+        # look like an orphan, and a live connection would lose its schedule
+        racing_id = 999999
+        add_entry(INGESTION_TASK_NAME, racing_id, "born-mid-scan")
+        real_iter = tasks.iter_owned_schedule_entries
+
+        def iter_then_create_the_connection(task_name):
+            entries = list(real_iter(task_name))
+            if task_name == INGESTION_TASK_NAME:
+                NetworkConnectionFactory(id=racing_id)
+            return iter(entries)
+
+        with patch.object(
+            tasks, "iter_owned_schedule_entries", iter_then_create_the_connection
+        ):
+            pruned = prune_orphaned_periodic_tasks()
+
+        self.assertEqual(pruned, [])
+        self.assertEqual(len(find_periodic_tasks_for(INGESTION_TASK_NAME, racing_id)), 1)
+
+    def test_a_string_id_naming_a_live_connection_is_not_pruned(self):
+        connection = NetworkConnectionFactory()
+        add_entry(
+            INGESTION_TASK_NAME,
+            connection.id,
+            "string-id",
+            args=json.dumps([str(connection.id)]),
+        )
+
+        pruned = prune_orphaned_periodic_tasks()
+
+        self.assertEqual(pruned, [])
 
     def test_the_management_command_removes_orphans(self):
         add_entry(INGESTION_TASK_NAME, 999999, "left-behind")

--- a/adl/src/adl/monitoring/health.py
+++ b/adl/src/adl/monitoring/health.py
@@ -512,7 +512,8 @@ class _ChecklistBuilder:
         if self.schedule_entries.duplicated:
             return (CheckState.WARNING,
                     _("%(count)d schedule entries run this connection; which one "
-                      "beat fires is undefined. Delete the extras.")
+                      "beat fires is undefined. Re-saving the connection "
+                      "collapses them back to one.")
                     % {"count": len(self.schedule_entries.entries)},
                     False)
         return CheckState.OK, _("Exactly one schedule entry exists."), False

--- a/docs/user_guide/dispatch_troubleshooting.md
+++ b/docs/user_guide/dispatch_troubleshooting.md
@@ -123,6 +123,25 @@ Dispatch runs on its own dedicated worker, so restarting it does **not**
 interrupt in-flight data collection (ingestion runs on
 `adl_celery_worker_adl`).
 
+## Schedule entries left behind by a deleted channel
+
+Deleting a dispatch channel (or a network connection) removes its scheduler
+entry along with it. Deployments upgraded from an older version can still be
+carrying entries for channels and connections that were deleted before that
+was true. They keep firing on their interval against an id that no longer
+exists — a recurring task failure in the logs for something you cannot see in
+the admin.
+
+To list them without changing anything:
+
+```bash
+docker compose exec adl adl prune_orphaned_periodic_tasks --dry-run
+```
+
+Drop the `--dry-run` to remove them. The command only ever touches entries
+whose connection or channel is genuinely gone, so it is safe to run on a live
+system; it is worth running once after upgrading.
+
 (tuning-the-per-channel-knobs)=
 ## Tuning the per-channel knobs
 


### PR DESCRIPTION
Closes #159.

Deleting a `NetworkConnection` or `DispatchChannel` left its `django-celery-beat` `PeriodicTask` behind, **enabled**, firing forever against an id nobody can see in the admin. Ingestion logged an error every interval; `perform_channel_dispatch` raises on a missing channel, so dispatch orphans failed hard every interval.

## What changed

- **`post_delete` receivers** for `NetworkConnection` and `DispatchChannel` remove the schedule entries. Connected for the base models as well as `__subclasses__()`, so a delete issued through the base manager is covered too — the receivers are idempotent, so a double call is a no-op.
- **Entries are resolved by `task` + `args`, not by `repr(sig)`.** `celery` is unpinned here (it arrives transitively via `django-celery-beat`), so the generated name is not stable across the 26+ installations. A name drift used to make `update_or_create` miss the existing row and add a second one, leaving the old row enabled — two ticks per interval. The writer now updates the matched row in place and collapses any surplus rows back to one.
- **`prune_orphaned_periodic_tasks()`** for deployments that already accumulated orphans, exposed as `adl prune_orphaned_periodic_tasks [--dry-run]`. Entries whose args can't be parsed are left alone — there's no owner to check them against, so deleting them would be a guess.

`find_connection_schedule_entries` (used by the monitoring diagnostic) keeps its signature and semantics; it now delegates to the shared `find_periodic_tasks_for` lookup.

## Testing

24 new tests in `adl/src/adl/core/tests/test_periodic_task_lifecycle.py`, written test-first, covering the writer (create / idempotent rewrite / drifted name / duplicate collapse / other objects untouched), both delete receivers, the lookup edge cases, and the prune helper and its command including `--dry-run`.

Full suite: 560 tests, passing.