### PR TITLE
fix: redact a password-only broker URL, constrain django-celery-beat

### DIFF
--- a/adl/constraints.txt
+++ b/adl/constraints.txt
@@ -11,3 +11,10 @@
 celery==5.6.3
 kombu==5.6.2
 redis==8.0.1
+
+# Not a broker-signal library — it carries no version guard on the ingestion
+# diagnostic — but core writes beat schedules through its model API
+# (core/tasks.py, monitoring/health.py), and that code depends on how a
+# PeriodicTask's task+args identify an owner. A plugin resolving it away
+# would move the schedule writer, not a diagnostic.
+django-celery-beat==2.9.0

--- a/adl/src/adl/core/redaction.py
+++ b/adl/src/adl/core/redaction.py
@@ -78,8 +78,11 @@ _KEY_VALUE_RE = re.compile(
 # A bare ``Bearer <credential>`` with no key in front of it.
 _SCHEME_RE = re.compile(r"(?i)\b(?P<scheme>" + _SCHEMES + r")\s+(?P<token>\S+)")
 
-# scheme://user:password@host — the password is in the URL itself.
-_USERINFO_RE = re.compile(r"(?i)\b([a-z][a-z0-9+.\-]*://)[^/\s:@]+:[^/\s@]*@")
+# scheme://user:password@host — the password is in the URL itself. The user
+# half may be empty: ``redis://:password@host:6379/0`` is the canonical form
+# of a broker URL for a Redis secured with ``requirepass``, and that URL is
+# what a kombu connection error carries into an activity-log message.
+_USERINFO_RE = re.compile(r"(?i)\b([a-z][a-z0-9+.\-]*://)[^/\s:@]*:[^/\s@]*@")
 
 # A whole mapping key that names a secret. In parsed data the key and its
 # value are already separate, so the value goes whatever it looks like —

--- a/adl/src/adl/core/tests/test_dependency_pins.py
+++ b/adl/src/adl/core/tests/test_dependency_pins.py
@@ -24,6 +24,16 @@ from adl.core.broker import (
 
 _PIN_PATTERN = re.compile(r"^([A-Za-z0-9._-]+)==(\S+)\s*$")
 
+# Libraries core drives through their own APIs but which carry no version
+# guard: the ingestion diagnostic makes no claim about them, so they have no
+# tested range to sit inside. They still have to be pinned in both files —
+# the beat-schedule writer depends on how a PeriodicTask's task+args identify
+# an owner, and a plugin install resolving that away would move the writer.
+SCHEDULE_LIBRARIES = ("django-celery-beat",)
+
+# Everything constraints.txt must bind, guarded or not.
+CONSTRAINED_LIBRARIES = tuple(BROKER_LIBRARIES) + SCHEDULE_LIBRARIES
+
 
 def _project_root():
     """The directory holding requirements.txt — the checkout's ``adl/`` in
@@ -48,9 +58,9 @@ def _pins(filename):
 
 
 class BrokerStackPinTests(SimpleTestCase):
-    def test_broker_libraries_are_pinned_exactly_in_requirements(self):
+    def test_constrained_libraries_are_pinned_exactly_in_requirements(self):
         pins = _pins("requirements.txt")
-        for name in BROKER_LIBRARIES:
+        for name in CONSTRAINED_LIBRARIES:
             self.assertIn(
                 name, pins,
                 "%s must be a direct, exactly-pinned dependency: first-party "
@@ -62,7 +72,7 @@ class BrokerStackPinTests(SimpleTestCase):
         # stack; a drifted copy would let a plugin resolve past the pins
         requirement_pins = _pins("requirements.txt")
         constraint_pins = _pins("constraints.txt")
-        for name in BROKER_LIBRARIES:
+        for name in CONSTRAINED_LIBRARIES:
             self.assertEqual(
                 constraint_pins.get(name), requirement_pins.get(name),
                 "constraints.txt must carry the same %s pin as "

--- a/adl/src/adl/core/tests/test_redaction.py
+++ b/adl/src/adl/core/tests/test_redaction.py
@@ -79,8 +79,24 @@ class RedactUrlUserinfoTests(SimpleTestCase):
             "ftp://***:***@ftp.example.org/in/",
         )
 
+    def test_redacts_userinfo_with_an_empty_user(self):
+        # The broker URL of a Redis secured with ``requirepass`` has no user
+        # half. It reaches this function through kombu's connection errors,
+        # so the form that carries a real deployment's password must not be
+        # the one form the pattern misses.
+        self.assertEqual(
+            redact_secrets("Cannot connect to redis://:hunter2@adl_redis:6379/0"),
+            "Cannot connect to redis://***:***@adl_redis:6379/0",
+        )
+
     def test_leaves_a_url_without_userinfo_alone(self):
         text = "https://example.org:8443/data"
+        self.assertEqual(redact_secrets(text), text)
+
+    def test_leaves_a_port_and_path_that_resemble_userinfo_alone(self):
+        # The user half went from "one or more" to "zero or more" characters;
+        # a colon in a host:port or in a path must still not read as one.
+        text = "Timed out reading https://example.org:8443/keys/a:b@2024"
         self.assertEqual(redact_secrets(text), text)
 
 


### PR DESCRIPTION
Two follow-ups found sweeping `main` after #212–#217. Both sit in the same class as the fixes they follow.

## 1. `redact_secrets()` missed `scheme://:password@host`

The userinfo pattern required a non-empty user half:

| input | before | after |
|---|---|---|
| `ftp://alice:hunter2@host/in/` | `ftp://***:***@host/in/` | unchanged |
| `redis://:hunter2@host:6379/0` | **verbatim** | `redis://***:***@host:6379/0` |

The password-only form is the canonical one for a Redis secured with `requirepass`, and `config/settings/base.py:293` sets `CELERY_BROKER_URL = REDIS_URL` straight from the operator's env. A kombu connection error carrying that URL reaches operator-visible text through both surfaces this function guards — `TaskLogger` writing `StationLinkActivityLog.message` (`core/logging.py:42`) and `TaskResultSerializer` redacting stored tracebacks on read (`monitoring/serializers.py:40`). So the one form that carries a real deployment's password was the one form the pattern let through.

The user half is now zero-or-more. A `host:port` and a path colon must still not read as userinfo; there's a test for that alongside the leak case.

**Deployment note:** rows already stored keep the unredacted text — the backfill in `monitoring/0010_redact_stored_secrets.py` ran with the old pattern. Re-running it is a deployment decision, not a migration to re-point.

## 2. `django-celery-beat` was not in `constraints.txt`

Pinned in `requirements.txt` (2.9.0) but absent from the constraints file, so a plugin's unconstrained `pip install` into the shared virtualenv could resolve it away.

It is *not* a broker-signal library — the ingestion diagnostic makes no claim about it and it gets no tested range — but since #217 core drives its model API directly (`core/tasks.py:12`, `monitoring/health.py:33`), and the beat-schedule writer depends on how a `PeriodicTask`'s task+args identify an owner. Moving it moves the writer, not a diagnostic.

`test_dependency_pins` now splits the two ideas apart: `CONSTRAINED_LIBRARIES` (must be pinned in both files) covers the guarded stack plus `django-celery-beat`, while the tested-range coupling stays on `BROKER_LIBRARIES` alone — the only set with ranges to sit inside.

## Testing

- Full suite: **566 passed** (was 564 on `main`)
- Mutation-checked the new guard: dropping the `django-celery-beat` line from `constraints.txt` fails `test_constraints_file_mirrors_the_requirements_pins` with `None != '2.9.0'`, then restored
- The redaction leak case was confirmed failing against the old pattern in-container before the fix