### PR TITLE
fix: derive the backfill's pre-filter from the redactor's own pattern

### DIFF
--- a/adl/src/adl/core/redaction.py
+++ b/adl/src/adl/core/redaction.py
@@ -29,7 +29,14 @@ masking destroys the error text operators depend on.
 
 import re
 
-__all__ = ["REDACTED", "redact_json", "redact_secrets"]
+__all__ = [
+    "REDACTED",
+    "SCHEME_NAMES",
+    "SENSITIVE_SUFFIXES",
+    "USERINFO_BODY_TEMPLATE",
+    "redact_json",
+    "redact_secrets",
+]
 
 REDACTED = "***"
 
@@ -82,7 +89,17 @@ _SCHEME_RE = re.compile(r"(?i)\b(?P<scheme>" + _SCHEMES + r")\s+(?P<token>\S+)")
 # half may be empty: ``redis://:password@host:6379/0`` is the canonical form
 # of a broker URL for a Redis secured with ``requirepass``, and that URL is
 # what a kombu connection error carries into an activity-log message.
-_USERINFO_RE = re.compile(r"(?i)\b([a-z][a-z0-9+.\-]*://)[^/\s:@]*:[^/\s@]*@")
+#
+# Kept as a template because the backfill (monitoring/0010) needs the same
+# shape for its SQL pre-filter, where whitespace is spelled ``[:space:]``.
+# Deriving both from one source is what stops the sweep from missing what
+# this catches — the discipline SENSITIVE_SUFFIXES already imposes on the
+# word list, applied to the one branch that had been retyped by hand.
+USERINFO_BODY_TEMPLATE = r"://[^/{space}:@]*:[^/{space}@]*@"
+
+_USERINFO_RE = re.compile(
+    r"(?i)\b([a-z][a-z0-9+.\-]*)" + USERINFO_BODY_TEMPLATE.format(space=r"\s")
+)
 
 # A whole mapping key that names a secret. In parsed data the key and its
 # value are already separate, so the value goes whatever it looks like —
@@ -129,7 +146,7 @@ def redact_secrets(text):
     if not isinstance(text, str):
         text = str(text)
 
-    text = _USERINFO_RE.sub(rf"\1{REDACTED}:{REDACTED}@", text)
+    text = _USERINFO_RE.sub(rf"\g<1>://{REDACTED}:{REDACTED}@", text)
     text = _KEY_VALUE_RE.sub(rf"\g<key>\g<sep>{REDACTED}", text)
     text = _SCHEME_RE.sub(_mask_scheme, text)
 

--- a/adl/src/adl/monitoring/migrations/0010_redact_stored_secrets.py
+++ b/adl/src/adl/monitoring/migrations/0010_redact_stored_secrets.py
@@ -22,13 +22,17 @@ not something a migration should make silently.
 
 from django.db import migrations
 
-from adl.core.redaction import SCHEME_NAMES, SENSITIVE_SUFFIXES
+from adl.core.redaction import (
+    SCHEME_NAMES,
+    SENSITIVE_SUFFIXES,
+    USERINFO_BODY_TEMPLATE,
+)
 
 BATCH_SIZE = 1000
 
 # Cheap SQL pre-filter: any row whose text mentions a credential-ish word at
-# all. Built from the redactor's own vocabulary — retyping the word list here
-# is how the backfill would come to miss what the forward fix catches. The
+# all. Built from the redactor's own vocabulary — retyping any of it here is
+# how the backfill would come to miss what the forward fix catches. The
 # redactor still decides whether anything is really there; this only keeps
 # the sweep from loading every log row ever written.
 #
@@ -41,9 +45,15 @@ _WORDS = "|".join(
 )
 _SCHEMES = "|".join(SCHEME_NAMES)
 
+# The userinfo branch is the redactor's own, with POSIX's spelling of
+# whitespace substituted in. It used to be a hand-copied second version, and
+# it drifted: the copy required a non-empty user half, so a row carrying
+# ``redis://:password@host`` never became a candidate at all.
+_USERINFO = USERINFO_BODY_TEMPLATE.format(space="[:space:]")
+
 CANDIDATE_REGEX = (
     rf"({_WORDS})[a-z]*[[:space:]]*[\"']?[[:space:]]*[:=]"
-    r"|://[^/@[:space:]]+:[^/@[:space:]]*@"
+    rf"|{_USERINFO}"
     rf"|({_SCHEMES})[[:space:]]"
 )
 

--- a/adl/src/adl/monitoring/tests/test_secret_backfill.py
+++ b/adl/src/adl/monitoring/tests/test_secret_backfill.py
@@ -125,6 +125,10 @@ class CandidateFilterTests(TestCase):
             "sent Token abcdef123456 upstream",
             "sent Digest abcdef123456 upstream",
             "ftp://alice:hunter2@ftp.example.org/in/",
+            # No user half — the broker URL of a Redis secured with
+            # ``requirepass``, and the shape both the redactor and this
+            # filter used to miss.
+            "Cannot connect to redis://:hunter2@adl_redis:6379/0",
         ]
 
         for shape in shapes:


### PR DESCRIPTION
Follow-up to #218. That PR closed the password-only userinfo leak going forward, but the backfill was still blind to it.

## The gap

`monitoring/0010` selects candidate rows with a cheap SQL pre-filter before handing them to the redactor. Its userinfo branch was a hand-copied second version of the redactor's pattern, carrying the same bug:

```python
r"|://[^/@[:space:]]+:[^/@[:space:]]*@"
#                   ^ non-empty user half
```

So a stored row reading `redis://:password@host:6379/0` never entered the candidate queryset, and the corrected redactor never saw it. Re-running the sweep as-is would not have helped — which was the plan I'd sketched at the end of #218.

The module comment already named this exact failure mode for the word list — it's why `SENSITIVE_SUFFIXES` is imported rather than retyped ("retyping the word list here is how the backfill would come to miss what the forward fix catches"). The userinfo branch was the one part that escaped that discipline, and it's where the drift happened.

## The fix

`USERINFO_BODY_TEMPLATE` is exported from `core.redaction` and formatted with each side's spelling of whitespace — `\s` for Python, `[:space:]` for POSIX. One source, two renderings.

`CandidateFilterTests` already exists to assert the pre-filter is never narrower than the redactor; its shape list simply had no password-only URL in it. Added.

## Why editing an applied migration is safe here

`0.8.8` was set 2026-07-31 (`97831f7`); `0010` landed 2026-08-03 (`c276de4`), with no version bump since — verified with `git merge-base --is-ancestor`. The repo has no tags, releases, or CI, so the version bump is the release marker and this migration is in no released version. For installs that haven't migrated, the change is strictly a correction.

**Caveat:** an install that pulled `main` directly since 2026-08-03 has already applied `0010` and keeps its unredacted rows — the sweep would need re-running by hand there.

## Testing

- Full suite: **566 passed**
- Mutation-checked from the single source: reverting the template's user half to `+` fails **both** guards — `CandidateFilterTests` (`not swept: 'Cannot connect to redis://:hunter2@...'`, real SQL) and the unit test — confirming the SQL branch genuinely follows the Python pattern now
- The new POSIX class `[^/[:space:]:@]` is exercised against Postgres by the backfill tests, which run the filter as real SQL