### PR TITLE
chore: bump version to 0.8.9, start a changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,93 @@
+# Changelog
+
+Notable changes to ADL core. Plugins are versioned separately in their own
+repositories.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+with one addition: each release carries an **Upgrade notes** section listing the
+migrations it ships and anything an operator must do *before* running them.
+Read that section before upgrading a deployment.
+
+This file starts at 0.8.9. Earlier history is in the git log.
+
+## [0.8.9] — 2026-08-03
+
+A maintenance release. Every change is a fix to how ADL behaves when something
+upstream is broken, or to what a failure is allowed to reveal.
+
+### Security
+
+- Credentials are no longer stored in operator-visible failure text. A source
+  that authenticates with a query parameter leaked its token into activity-log
+  messages, which the monitoring API then served back: `requests` puts the full
+  request URL in its `HTTPError` text, and core stored it verbatim. Redaction
+  now happens where the text is produced, so the stored row, the admin
+  rendering, the export and the worker log are all covered at once. Only a
+  named secret is removed and the key is kept, so a message still says which
+  credential was involved. (#214, #218, #219)
+- The manual-action admin views are gated on a change permission for the object
+  being acted on. They were registered with no check of their own, so the
+  effective gate was "any user who can log into the Wagtail admin" — including
+  an account provisioned purely to read the monitoring pages. The sharpest of
+  the five, `reset_channel_dispatch`, deletes the per-station locks that prevent
+  concurrent double-dispatch. (#216)
+
+### Fixed
+
+- A deleted network connection or dispatch channel no longer leaves its Celery
+  Beat schedule behind. The orphaned entry stayed enabled and fired forever
+  against an id nobody could see in the admin — ingestion logged an error every
+  interval, dispatch failed hard every interval. Deployments that have already
+  accumulated orphans can clear them with the new
+  `prune_orphaned_periodic_tasks` management command, which takes `--dry-run`.
+  (#217)
+- The task-monitor page no longer hangs on a broken broker. Its two Celery
+  `inspect()` calls used the app's default connection, which retries: measured
+  at ~12 s against a refused broker and ~150 s against a blackholed one, on a
+  page whose whole purpose is to be usable when things are broken. In-process
+  broker calls now go through one short-lived connection with ~1 s timeouts and
+  no retries. (#215)
+- A dispatch channel's "test connection" button is bounded at 15 s and
+  rate-limited to one press per minute. Nothing previously bounded how long a
+  channel could take or how often the button could be pressed, and the probe
+  runs synchronously in the web process — a blackholed S3 endpoint tied up a
+  worker for minutes per click, re-clickable. The return shape of
+  `test_connection` is also validated in core rather than trusted from the
+  plugin. (#212, #213)
+- The ingestion lock TTL and the stale-log sweep are derived from the batch
+  timeout rather than set independently, so they can no longer disagree with the
+  bound they are supposed to follow. (#210)
+- A plugin install can no longer resolve `django-celery-beat` away from core's
+  pin. Core drives its model API directly to write beat schedules, so a plugin
+  moving it would move the schedule writer. A plugin that genuinely needs a
+  different version now fails loudly at install time. (#218)
+
+### Added
+
+- The admin shows the effective per-station ingestion timeout. The configured
+  value is a batch budget, not a per-station one, and the two differ whenever a
+  connection has more than one station. (#210)
+
+### Upgrade notes
+
+Migrations in this release:
+
+- `core.0051` — metadata only (`help_text` on `ingest_timeout_seconds`).
+- `monitoring.0010` — **a data sweep over activity-log history.** It rewrites
+  stored rows in `StationLinkActivityLog`, `SourceProbeResult` and
+  `NetworkConnectionHealth`, replacing credentials with `***`. Irreversible by
+  design: the reverse is a no-op because the secret is gone, which is the point.
+
+**Before migrating,** if this deployment has enabled TimescaleDB compression on
+old activity-log chunks, decompress them. Timescale refuses updates to a
+compressed chunk, and the migration deliberately does not decompress for you —
+that is a deployment decision, not something a migration should do silently.
+Installs without compression need do nothing.
+
+After migrating, consider clearing any orphaned beat schedules left by
+connections or channels deleted under earlier versions:
+
+```bash
+adl prune_orphaned_periodic_tasks --dry-run   # review first
+adl prune_orphaned_periodic_tasks
+```

--- a/adl/src/adl/version.py
+++ b/adl/src/adl/version.py
@@ -1,6 +1,6 @@
 # major.minor.patch.release.number
 # release must be one of alpha, beta, rc, or final
-VERSION = (0, 8, 8, "final", 0)
+VERSION = (0, 8, 9, "final", 0)
 
 
 def get_semver_version(version):


### PR DESCRIPTION
Ten PRs have landed since 0.8.8 was set on 2026-07-31 (#208, #210, #212–#219), including two migrations and the credential-redaction work. With no tags, releases or CI in this repo, the `version.py` bump is the only signal a deployment has that there's something to pull — so none of it reaches the 26 NMHSs until this moves.

## Changelog

Starts at 0.8.9. Backfilling 0.8.0–0.8.8 would be archaeology across ~200 commits for little benefit; the file says where earlier history lives rather than pretending to be complete.

[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format, with one addition: each release carries an **Upgrade notes** section naming the migrations it ships and what must happen before they run. Standard Keep a Changelog has nowhere to put "decompress your Timescale chunks first", and that's precisely the line an operator must read *before* `migrate`:

> `monitoring.0010` rewrites stored rows across activity-log history. If the deployment has enabled TimescaleDB compression on old chunks, decompress them first — Timescale refuses updates to a compressed chunk, and the migration deliberately does not decompress for you.

The section also points at `prune_orphaned_periodic_tasks` for installs carrying orphaned beat schedules from connections deleted under earlier versions.

## Not in this PR

- **Tags.** There are none in the repo, which is why the 0.8.8 boundary had to be reconstructed with `merge-base` while reviewing #219. Worth adding `v0.8.9` (and possibly `v0.8.8` retroactively at 9d80123) so releases become diffable — but that's a push of new refs, so it's your call, and it's why the changelog carries no `compare/` link yet.
- **A GitHub release.** If you want one, the body should link to the changelog section rather than restate it.

## Testing

- `test_dependency_pins` passes (it reads `requirements.txt`, unaffected by the bump)
- `adl.__version__` resolves to `0.8.9` in the container
- No other file in the repo referenced `0.8.8`