### PR TITLE
Station-link listing buttons via get_extra_model_admin_links + boilerplate worker fix

### DIFF
--- a/adl/src/adl/core/utils.py
+++ b/adl/src/adl/core/utils.py
@@ -283,16 +283,14 @@ def make_registrable_viewset(model_cls, **kwargs):
     return ViewSetCls()
 
 
-def get_connection_list_more_buttons(connection):
-    buttons = [
-        ListingButton(
-            gettext("Ingestion Diagnostic"),
-            url=reverse("connection_health", args=[connection.id]),
-            icon_name="crosshairs",
-        )
-    ]
-    if hasattr(connection, "get_extra_model_admin_links"):
-        extra_links = connection.get_extra_model_admin_links()
+def get_extra_model_admin_link_buttons(instance):
+    """
+    Builds ListingButtons from an instance's get_extra_model_admin_links(),
+    for models (connections, station links) that expose extra admin pages.
+    """
+    buttons = []
+    if hasattr(instance, "get_extra_model_admin_links"):
+        extra_links = instance.get_extra_model_admin_links()
         for link in extra_links:
             label = link.get("label", None)
             url = link.get("url", None)
@@ -307,6 +305,18 @@ def get_connection_list_more_buttons(connection):
                         attrs=attrs,
                     )
                 )
+    return buttons
+
+
+def get_connection_list_more_buttons(connection):
+    buttons = [
+        ListingButton(
+            gettext("Ingestion Diagnostic"),
+            url=reverse("connection_health", args=[connection.id]),
+            icon_name="crosshairs",
+        )
+    ]
+    buttons.extend(get_extra_model_admin_link_buttons(connection))
     return buttons
 
 

--- a/adl/src/adl/core/viewsets.py
+++ b/adl/src/adl/core/viewsets.py
@@ -15,7 +15,11 @@ from .models import (
     DataParameter,
     Unit
 )
-from .utils import get_dispatch_channel_more_buttons, get_connection_list_more_buttons
+from .utils import (
+    get_dispatch_channel_more_buttons,
+    get_connection_list_more_buttons,
+    get_extra_model_admin_link_buttons,
+)
 
 ADLET_MODELS = []
 
@@ -79,6 +83,13 @@ class AdletIndexView(generic.IndexView):
         ]
         
         return columns
+
+
+class StationLinkIndexView(AdletIndexView):
+    def get_list_more_buttons(self, instance):
+        buttons = super().get_list_more_buttons(instance)
+        buttons.extend(get_extra_model_admin_link_buttons(instance))
+        return buttons
 
 
 class ConnectionIndexView(generic.IndexView):

--- a/adl/src/adl/core/wagtail_hooks.py
+++ b/adl/src/adl/core/wagtail_hooks.py
@@ -54,6 +54,7 @@ from .viewsets import (
     DispatchChannelEditView,
     DispatchChannelDeleteView,
     StationLinkInspectView,
+    StationLinkIndexView,
     StationLinkAddView,
     StationLinkEditView,
     StationLinkDeleteView
@@ -144,6 +145,7 @@ def get_connection_viewsets():
                 station_link_viewset_kwargs = {
                     "list_display": ["__str__", "wigos_id"],
                     "list_filter": ["network_connection"],
+                    "index_view_class": StationLinkIndexView,
                     "add_view_class": StationLinkAddView,
                     "edit_view_class": StationLinkEditView,
                     "delete_view_class": StationLinkDeleteView,

--- a/plugin-boilerplate/{{ cookiecutter.project_slug }}/docker-compose.yml
+++ b/plugin-boilerplate/{{ cookiecutter.project_slug }}/docker-compose.yml
@@ -52,10 +52,48 @@ services:
     tty: true              # enables terminal support
     stdin_open: true       # allows interactive input
 
-  adl_celery_worker:
+  # Three queue-specific workers, mirroring the core stack: the entrypoint
+  # has no generic "celery-worker" command, and core routes ingestion to
+  # the "adl" queue and outbound dispatch to the "dispatch" queue -- a
+  # single default-queue worker would never consume them.
+  adl_celery_worker_default:
     image: {{ cookiecutter.project_slug }}_dev
-    command: celery-worker
-    container_name: {{ cookiecutter.project_slug }}-worker
+    command: celery-worker-default
+    container_name: {{ cookiecutter.project_slug }}-worker-default
+    env_file:
+      - .env
+    environment:
+      <<: *adl-variables
+      WAIT_HOSTS: adl_db:5432,adl_redis:6379,adl:8000
+    depends_on:
+      - adl
+    volumes:
+      - ./plugins/{{ cookiecutter.project_module }}:/adl/plugins/{{ cookiecutter.project_module }}
+    # Open stdin and tty so when attaching key input works as expected.
+    stdin_open: true
+    tty: true
+
+  adl_celery_worker_adl:
+    image: {{ cookiecutter.project_slug }}_dev
+    command: celery-worker-adl
+    container_name: {{ cookiecutter.project_slug }}-worker-adl
+    env_file:
+      - .env
+    environment:
+      <<: *adl-variables
+      WAIT_HOSTS: adl_db:5432,adl_redis:6379,adl:8000
+    depends_on:
+      - adl
+    volumes:
+      - ./plugins/{{ cookiecutter.project_module }}:/adl/plugins/{{ cookiecutter.project_module }}
+    # Open stdin and tty so when attaching key input works as expected.
+    stdin_open: true
+    tty: true
+
+  adl_celery_worker_dispatch:
+    image: {{ cookiecutter.project_slug }}_dev
+    command: celery-worker-dispatch
+    container_name: {{ cookiecutter.project_slug }}-worker-dispatch
     env_file:
       - .env
     environment:


### PR DESCRIPTION
## Summary

Two small, related changes:

### feat(admin): surface station-link extra admin links as listing buttons
Connections already expose extra plugin admin pages on their listing rows via `get_extra_model_admin_links()`; station links had no equivalent, so a plugin page scoped to one station could not be reached from the listing. This extracts the shared link→`ListingButton` loop into `get_extra_model_admin_link_buttons()` and adds a `StationLinkIndexView` that appends those buttons, wired into the auto-registered station-link viewsets.

First consumer: the EUMETSAT DCS plugin's new per-station variable-mapping page (wmo-raf/adl-eumetsat-dcs-plugin#1), which links itself from the station-link listing row through this hook.

### fix(boilerplate): run the three queue-specific celery workers
The plugin compose template still used the entrypoint's removed generic `celery-worker` command, so scaffolded plugins shipped a worker container that printed the usage help and exited 1. Even when that command existed, it consumed only the default queue — never the `adl` ingestion or `dispatch` queues tasks are actually routed to, so scheduled ingestion piled up unconsumed. The template now mirrors the core stack's `celery-worker-default` / `celery-worker-adl` / `celery-worker-dispatch` services.

Existing plugin repos scaffolded from the old template carry the same dead worker and need the same one-line-per-service fix when next touched.

## Testing
- Verified in the EUMETSAT DCS plugin dev stack: all three workers boot, each consuming its correct queue, and scheduled ingestion runs.
- Compose config validated with `docker compose config`.