### PR TITLE
fix: give Postgres time to finish its shutdown checkpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,10 @@ services:
     container_name: adl_db
     image: timescale/timescaledb-ha:pg15
     restart: unless-stopped
+    # The image stops on SIGINT — a Postgres fast shutdown, which must finish a
+    # checkpoint that flushes shared_buffers to disk. Docker's 10s default kills
+    # it mid-checkpoint, leaving an unclean shutdown on every stop.
+    stop_grace_period: ${ADL_DB_STOP_GRACE_PERIOD:-5m}
     command: postgres -c max_connections=${POSTGRES_MAX_CONNECTIONS:-300} -c shared_buffers=${POSTGRES_SHARED_BUFFERS:-2GB}
     environment:
       - POSTGRES_USER=${ADL_DB_USER:-?}


### PR DESCRIPTION
## Problem

`adl_db` has no `stop_grace_period`, so Docker uses its **10 second** default. The `timescale/timescaledb-ha` image sets `STOPSIGNAL SIGINT` — a Postgres *fast shutdown*, which must complete a shutdown checkpoint flushing `shared_buffers` (2 GB by default) to disk before exiting. That does not reliably finish in 10 seconds, so Docker `SIGKILL`s it mid-checkpoint.

Every `docker compose down`, `restart` and host reboot has therefore been leaving an unclean shutdown, on every deployment. Repair of the resulting torn pages then rests entirely on the storage honouring `fsync` — which not all of our field hardware does.

## How it surfaced

A production instance lost the HOT chain parent on `django_celery_beat_periodictasks` after a power cut. `PeriodicTasks` is a single row updated constantly, and `last_update` is unindexed, so every write is a HOT update — the versions chain off one line pointer rather than getting their own index entries. With the parent gone, a sequential scan returned **11 live-looking versions of the one row**:

```
ERROR: failed to find parent tuple for heap-only tuple at (0,27)
       in table "django_celery_beat_periodictasks"
```

`PeriodicTasks.last_change()` does `get(ident=1)` and catches only `DoesNotExist`, so `MultipleObjectsReturned` escaped, celery beat exited 1, and `restart: unless-stopped` looped it for **14 days with no ingestion or dispatch**. The primary key was intact throughout and never violated.

Postgres logs on that host still show the pattern independently of the power cut:

```
LOG: database system shutdown was interrupted; last known up at ...
LOG: syncing data directory (fsync), elapsed time: 160.00 s
LOG: database system was not properly shut down; automatic recovery in progress
```

## Change

```yaml
stop_grace_period: ${ADL_DB_STOP_GRACE_PERIOD:-5m}
```

Overridable like the neighbouring `POSTGRES_SHARED_BUFFERS` / `POSTGRES_MAX_CONNECTIONS` knobs. `docker-compose.dev.yml` is an overlay that defines no `adl_db`, so the dev stack inherits it.

## Verification

Recreated `adl_db` locally:

```
StopTimeout=300  StopSignal=SIGINT
```

and stopping it produced what was previously missing:

```
LOG: checkpoint starting: shutdown immediate
LOG: checkpoint complete: wrote 575 buffers ...
LOG: database system is shut down
```

A completed shutdown checkpoint, so the next start skips crash recovery entirely.

## Deploying this has a trap

`stop_grace_period` is fixed when a container is **created**, so a running `adl_db` still has 10 seconds — including for the stop that `docker compose up -d` performs to recreate it. Recreating it naively crash-kills the database one last time. Stop it explicitly first:

```bash
docker compose stop -t 300 adl_db
docker compose up -d adl_db
docker compose logs adl_db | tail -20   # want NO "not properly shut down"
```

## Not addressed here

This removes the routine crash-kills. It does **not** address a storage layer that acknowledges an `fsync` it hasn't honoured — a genuine power loss still lands on an unprotected checkpoint. Sites need a UPS with automatic graceful shutdown, and `data_checksums` enabled so torn pages are detected rather than silently served.