### PR TITLE
feat: close the ingestion diagnostic with its run button, gated on a consumer

### DIFF
--- a/adl/src/adl/monitoring/templates/monitoring/connection_health.html
+++ b/adl/src/adl/monitoring/templates/monitoring/connection_health.html
@@ -129,24 +129,6 @@
             </p>
         {% endif %}
 
-        {% if show_run_button %}
-            {% comment %}
-                Page-level and connection-wide: the run spans layers 1-6.
-                Hidden rather than disabled when unpermitted, and enabled
-                during cooldown: a press inside it answers with the last
-                run's age, not a refusal.
-            {% endcomment %}
-            <form method="post"
-                  action="{% url 'connection_run_now' connection.id %}"
-                  class="health-run-form">
-                {% csrf_token %}
-                <button type="submit" class="button">{% trans "Run ingestion now" %}</button>
-                <p class="health-run-form__hint">
-                    {% trans "Enqueues a run identical to a scheduled tick, through the real queue and workers. It stamps the manual-run slot, never the scheduler heartbeat." %}
-                </p>
-            </form>
-        {% endif %}
-
         {# Precondition band: assertions about configuration, above the ladder #}
         <h2 class="w-text-h3">{% trans "Preconditions" %}</h2>
         {% include "monitoring/partials/health_check_table.html" with checks=checklist.precondition %}
@@ -206,6 +188,27 @@
                 </form>
             {% endif %}
         {% endfor %}
+
+        {% if show_run_button %}
+            {% comment %}
+                Page-level and connection-wide: the run spans layers 1-6, so
+                it closes the ladder rather than heading the page — the
+                reader has the whole diagnosis before the action. Hidden
+                rather than disabled when unpermitted, when the connection is
+                off, or when no worker consumes the ingestion queue; enabled
+                during cooldown and while a run is in flight, where a press
+                answers with the running run's age, not a refusal.
+            {% endcomment %}
+            <form method="post"
+                  action="{% url 'connection_run_now' connection.id %}"
+                  class="health-run-form">
+                {% csrf_token %}
+                <button type="submit" class="button">{% trans "Run ingestion now" %}</button>
+                <p class="health-run-form__hint">
+                    {% trans "Enqueues a run identical to a scheduled tick, through the real queue and workers. It stamps the manual-run slot, never the scheduler heartbeat." %}
+                </p>
+            </form>
+        {% endif %}
 
         {% comment %}
             Verdict history: the append-only transitions log, paginated in

--- a/adl/src/adl/monitoring/tests/test_manual_run_view.py
+++ b/adl/src/adl/monitoring/tests/test_manual_run_view.py
@@ -18,8 +18,11 @@ from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone as dj_tz
 
+from django_celery_beat.models import IntervalSchedule, PeriodicTask
+
 from adl.core.broker import IngestionQueueHealth, RunningIngestionTask
 from adl.core.models import NetworkConnectionHeartbeat
+from adl.core.tasks import INGESTION_TASK_NAME
 from adl.core.tests.factories import StationLinkFactory
 from adl.monitoring.views.health import (
     MANUAL_RUN_COOLDOWN_CAP_SECONDS,
@@ -30,6 +33,8 @@ UNOBSERVED = IngestionQueueHealth(queue_depth=None, worker_consuming=None,
                                   running_tasks=None)
 IDLE = IngestionQueueHealth(queue_depth=0, worker_consuming=True,
                             running_tasks=())
+NOT_CONSUMING = IngestionQueueHealth(queue_depth=0, worker_consuming=False,
+                                     running_tasks=())
 
 
 def observed_running(connection_id, age_seconds=30.0):
@@ -259,3 +264,69 @@ class ManualRunCaptionTests(ManualRunViewTestCase):
         response = self.client.get(self.page_url)
 
         self.assertNotContains(response, "triggered manually")
+
+
+class ManualRunButtonVisibilityTests(ManualRunViewTestCase):
+    """
+    The button is hidden only where a press provably achieves nothing.
+
+    The page's own checklist resolves the broker through
+    ``adl.monitoring.health``, not through the view module — the view's patch
+    covers the press path only — so these tests substitute that name. They
+    also have to make layer 1 pass: while the ladder fails above it the
+    worker check is emitted as SKIPPED and never consults a broker at all.
+    """
+
+    def page_broker(self, observation):
+        return patch("adl.monitoring.health.get_ingestion_queue_health",
+                     return_value=observation)
+
+    def reach_the_worker_layer(self):
+        schedule, _ = IntervalSchedule.objects.get_or_create(
+            every=self.connection.interval, period=IntervalSchedule.MINUTES
+        )
+        PeriodicTask.objects.create(
+            name=f"ingest-{self.connection.id}",
+            task=INGESTION_TASK_NAME,
+            args=f"[{self.connection.id}]",
+            interval=schedule,
+            last_run_at=dj_tz.now(),
+        )
+        NetworkConnectionHeartbeat.objects.create(
+            connection=self.connection, last_run_at=dj_tz.now()
+        )
+
+    def test_hidden_when_no_worker_consumes_the_ingestion_queue(self):
+        self.reach_the_worker_layer()
+
+        with self.page_broker(NOT_CONSUMING):
+            response = self.client.get(self.page_url)
+
+        self.assertNotContains(response, "Run ingestion now")
+        self.assertNotContains(response, self.url)
+
+    def test_shown_when_a_worker_is_consuming(self):
+        self.reach_the_worker_layer()
+
+        with self.page_broker(IDLE):
+            response = self.client.get(self.page_url)
+
+        self.assertContains(response, "Run ingestion now")
+
+    def test_shown_when_the_broker_did_not_answer(self):
+        # Unknown is not down: a silent broker must not remove the button
+        self.reach_the_worker_layer()
+
+        with self.page_broker(UNOBSERVED):
+            response = self.client.get(self.page_url)
+
+        self.assertContains(response, "Run ingestion now")
+
+    def test_shown_when_beat_has_stopped(self):
+        # Layer 1 fails, so the worker check is SKIPPED rather than FAILED —
+        # and a manual run, which bypasses beat and goes straight to the
+        # queue, is the only way left to collect data
+        with self.page_broker(NOT_CONSUMING):
+            response = self.client.get(self.page_url)
+
+        self.assertContains(response, "Run ingestion now")

--- a/adl/src/adl/monitoring/views/health.py
+++ b/adl/src/adl/monitoring/views/health.py
@@ -27,7 +27,13 @@ from adl.core.source_checks import (
     run_station_source_check,
 )
 
-from ..constants import LAYER_LABELS, LAYER_SOURCE, LAYER_WORKER, PROBE_LAYER_IDS
+from ..constants import (
+    CheckState,
+    LAYER_LABELS,
+    LAYER_SOURCE,
+    LAYER_WORKER,
+    PROBE_LAYER_IDS,
+)
 from ..health import EVALUATED_LAYERS, evaluate_connection_health, probe_age_minutes
 from ..models import (
     NetworkConnectionHealth,
@@ -148,6 +154,21 @@ def connection_health(request, connection_id):
         and connection.source_probe_supported
     )
 
+    # The press enqueues the coordinator on the ingestion queue, so a queue
+    # nobody consumes swallows it: no run, no feedback, and the task fires
+    # late whenever a worker returns. That is the one state where the button
+    # provably achieves nothing. Only a definite FAILED hides it — SKIPPED
+    # means a layer-1 failure above (beat not ticking, no schedule entry),
+    # which is exactly when the manual run is the way to collect data, and
+    # UNSUPPORTED means unknown, never down.
+    worker_check = next(
+        (check for check in checklist.checks if check.id == "worker_consuming"),
+        None,
+    )
+    ingestion_queue_unconsumed = (
+        worker_check is not None and worker_check.state == CheckState.FAILED
+    )
+
     # The broker stack renders always — not only on drift, and regardless of
     # what the ladder concluded — because nothing else reports which broker
     # libraries a running installation actually has. "This process" is the
@@ -216,10 +237,12 @@ def connection_health(request, connection_id):
         "health": health,
         "first_failing_layer_label": LAYER_LABELS.get(checklist.first_failing_layer),
         "layer_groups": layer_groups,
-        # Hidden rather than disabled, like the probe button — and hidden on
-        # a disabled connection: there is nothing to run
+        # Hidden rather than disabled, like the probe button — and hidden
+        # wherever the press cannot do anything: a disabled connection has
+        # nothing to run, an unconsumed queue has nothing to run it
         "show_run_button": (can_manage_connection(request.user, connection)
-                            and connection.enabled),
+                            and connection.enabled
+                            and not ingestion_queue_unconsumed),
         "latest_run_was_manual": latest_run_was_manual(heartbeat),
         "heartbeat": heartbeat,
         "transitions_page": transitions_page,


### PR DESCRIPTION
Two changes to **Run ingestion now** on `/monitoring/connection/<id>/health/`.

## 1. Moved to the end of the ladder

It sat directly under the headline, above the Preconditions band and the entire diagnosis. The run spans layers 1–6, so it now closes the ladder instead of heading the page — the reader has the whole diagnosis before the action, and it sits alongside **Probe source now** as the page's other on-demand action. Verdict history stays as the trailing log.

```
  Preconditions           [table]
  Layer 1 — Schedule      [table]
  Layer 2 — Worker        [table] + broker libraries
  Layer 3 — Dispatch      [table]
  Layers 4–5 — Source     [table] + [ Probe source now ]
  Layer 6 — Records       [table]

→ [ Run ingestion now ]

  Verdict history         [table]
```

Deliberately **not** placed after Verdict history: that table paginates, so the button would land below page-2/3 controls and scroll away.

## 2. Hidden when nothing can consume the run

`show_run_button` was `can_manage_connection(...) and connection.enabled`. It now also requires that the `worker_consuming` check is not definitively `FAILED`.

The press enqueues the coordinator on the ingestion queue. A queue nobody consumes swallows it with no feedback, then fires it late whenever a worker returns — the one state where the button provably achieves nothing.

Every other failure keeps the button, because a manual run bypasses beat and goes straight to the queue:

| State | Button | Why |
|---|---|---|
| `worker_consuming` **FAILED** | hidden | no consumer; the press does nothing |
| `worker_consuming` **SKIPPED** | shown | a layer-1 failure above — beat down, no schedule entry — is exactly when the manual run is the only way to collect data |
| `worker_consuming` **WARNING** | shown | the broker didn't answer: unknown, never down |
| `MISCONFIGURED` (drift) | shown | drift is report-only; ingestion itself still runs |
| connection disabled / unpermitted | hidden | unchanged |

This follows the page's existing rule — *hidden when it can't be used at all, never disabled* — and leaves the press-time behaviour untouched: a press during cooldown or an in-flight run still answers with the running run's age rather than a refusal.

## Tests

Four new tests in `ManualRunButtonVisibilityTests`: hidden with no consumer, shown with a consumer, shown when the broker is silent, shown when beat has stopped.

One subtlety they encode: the page's checklist resolves the broker through `adl.monitoring.health`, **not** the view module, so the existing `views.health` patch doesn't reach it — that patch covers the press path only. The new tests substitute the right name and set up a passing layer 1, since while the ladder fails above it the worker check is emitted as `SKIPPED` and never consults a broker at all.

Full `adl.monitoring` suite: **228 tests, OK**.

## Context

The `SKIPPED` case is not hypothetical — it is the state a production instance sat in for 14 days while celery beat crash-looped (see #241). A rule that hid the button on any ladder failure would have removed the one mechanism still capable of collecting data.