### PR TITLE
chore: bump version to 0.8.10, changelog for the release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,72 @@ Read that section before upgrading a deployment.
 
 This file starts at 0.8.9. Earlier history is in the git log.
 
+## [0.8.10] — 2026-08-12
+
+A maintenance release. The headline is a database durability fix that affects
+every deployment; the rest is admin ergonomics and plugin-authoring documentation.
+
+### Fixed
+
+- The database container is given five minutes to shut down rather than Docker's
+  default ten seconds. The `timescaledb-ha` image stops on `SIGINT` — a Postgres
+  *fast shutdown*, which must complete a checkpoint flushing `shared_buffers`
+  (2 GB by default) to disk before it exits. Ten seconds does not reliably cover
+  that, so every `docker compose down`, `restart` and host reboot was
+  `SIGKILL`ing Postgres mid-checkpoint and leaving an unclean shutdown, on every
+  deployment. Repair of the resulting torn pages then rested entirely on the
+  storage honouring `fsync`. One installation lost the HOT chain parent on
+  `django_celery_beat_periodictasks` after a power cut, which made
+  `PeriodicTasks.last_change()` raise `MultipleObjectsReturned`; celery beat
+  crash-looped for 14 days with no ingestion or dispatch and nothing to announce
+  it. (#241)
+- Scaffolded plugins run the three queue-specific celery workers. The plugin
+  compose template still used the entrypoint's removed generic `celery-worker`
+  command, so a new plugin shipped a worker that printed usage help and exited 1
+  — and even when that command existed it consumed only the default queue, never
+  the `adl` ingestion or `dispatch` queues that tasks are actually routed to.
+  (#240)
+
+### Added
+
+- Station links surface their plugin's extra admin pages as listing buttons, as
+  connections already did through `get_extra_model_admin_links()`. A plugin page
+  scoped to a single station — a per-station variable-mapping editor, say — had
+  no way to be reached from the listing. (#240)
+- The ingestion diagnostic's **Run ingestion now** button now closes the layer
+  ladder instead of heading the page, so the whole diagnosis is read before the
+  action is offered. It is hidden when no worker is consuming the ingestion
+  queue, the one state where the press provably achieves nothing; every failure
+  a manual run can still help with — a stopped scheduler above all — keeps the
+  button, since the run bypasses beat and goes straight to the queue. (#242)
+- A plugin-authoring guide for the ingestion diagnostic contracts: the seven
+  contract surfaces a plugin can implement so layers 4, 5 and part of 6 report
+  something better than `UNSUPPORTED`, what each means per source archetype, and
+  the rules a retrofit is measured against. (#239)
+
+### Upgrade notes
+
+No migrations in this release.
+
+**The database fix needs one manual step, once.** `stop_grace_period` is fixed
+when a container is *created*, so a running `adl_db` still carries the ten-second
+timeout — including for the stop that `docker compose up -d` performs in order to
+recreate it. Recreating it without stopping it explicitly crash-kills the
+database one last time:
+
+```bash
+docker compose stop -t 300 adl_db   # clean shutdown under the old container
+docker compose up -d
+docker compose logs adl_db | tail -20
+```
+
+The last line should end in `database system is shut down` on the stop and show
+no `database system was not properly shut down` on the start.
+
+This bounds the routine crash-kills; it does not make a host safe from power
+loss. Sites still need a UPS with automatic graceful shutdown, and should enable
+`data_checksums` so that a torn page is detected rather than silently served.
+
 ## [0.8.9] — 2026-08-03
 
 A maintenance release. Every change is a fix to how ADL behaves when something

--- a/adl/src/adl/version.py
+++ b/adl/src/adl/version.py
@@ -1,6 +1,6 @@
 # major.minor.patch.release.number
 # release must be one of alpha, beta, rc, or final
-VERSION = (0, 8, 9, "final", 0)
+VERSION = (0, 8, 10, "final", 0)
 
 
 def get_semver_version(version):


### PR DESCRIPTION
Four PRs have landed since 0.8.9 was set on 2026-08-03. With no tags, releases or CI, the version bump is the only signal an operator has that there is something to pull — and this release carries a fix every deployment needs.

## Version

`0.8.9` → `0.8.10`. A patch bump, following 0.8.9's precedent: the **Added** entries are admin ergonomics and documentation, and **no migrations ship**.

## In this release

| PR | |
|---|---|
| #241 | `stop_grace_period` on `adl_db` — stops Docker `SIGKILL`ing Postgres mid-checkpoint on every stop |
| #242 | **Run ingestion now** moved to the end of the ladder, hidden when no worker consumes the queue |
| #240 | Station-link extra admin links as listing buttons; scaffolded plugins run the three queue-specific workers |
| #239 | Ingestion diagnostic contracts guide for plugin authors |

## The upgrade note is the point

`stop_grace_period` is fixed when a container is **created**, so a running `adl_db` still carries the old ten-second timeout — including during the very stop that `docker compose up -d` performs to recreate it. Pulling this release without stopping the database explicitly first crash-kills it one last time, which is precisely what the release fixes. The changelog spells out the sequence:

```bash
docker compose stop -t 300 adl_db
docker compose up -d
docker compose logs adl_db | tail -20
```

It also states plainly what the fix does *not* do: it bounds the routine crash-kills, but a host that loses power still needs a UPS with automatic graceful shutdown, and `data_checksums` enabled so a torn page is detected rather than silently served.